### PR TITLE
feat(DockerClient): add PortAlreadyAllocatedException for port conflict handling

### DIFF
--- a/src/Docker/Exception/PortAlreadyAllocatedException.php
+++ b/src/Docker/Exception/PortAlreadyAllocatedException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Testcontainers\Docker\Exception;
+
+/**
+ * Exception thrown when a port is already allocated by another process.
+ *
+ * This exception is used to indicate that an attempt to allocate a port
+ * has failed because the port is already in use. It extends the DockerException
+ * class to provide additional context specific to port allocation conflicts.
+ */
+class PortAlreadyAllocatedException extends DockerException
+{
+    /**
+     * Checks if the given output matches the "port is already allocated" error message.
+     *
+     * @param string $output The output to check.
+     * @return bool True if the output matches the error message, false otherwise.
+     */
+    public static function match($output)
+    {
+        return preg_match('/Error response from daemon: /', $output) !== false
+            && preg_match('/port is already allocated\.$/', $output) !== false;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new exception to handle port allocation conflicts in the Docker client. The most important changes include adding the `PortAlreadyAllocatedException` class, updating the `DockerClient` to throw this exception when a port conflict occurs, and adding unit tests to cover this new functionality.

### Exception Handling for Port Conflicts:

* [`src/Docker/Exception/PortAlreadyAllocatedException.php`](diffhunk://#diff-360a485a396d4282d7030e4eb682845cc04f675e4b1e5168153c6723f8866ea7R1-R25): Added a new exception class `PortAlreadyAllocatedException` to handle cases where a port is already allocated by another process. This class extends `DockerException` and includes a static method `match` to check if the error output matches the port allocation conflict message.

### Docker Client Updates:

* `src/Docker/DockerClient.php`: 
  * Imported the new `PortAlreadyAllocatedException` class.
  * Updated the `run` method to throw `PortAlreadyAllocatedException` if the error output indicates a port conflict.

### Unit Tests:

* `tests/Unit/Docker/DockerClientTest.php`: 
  * Imported the `PortAlreadyAllocatedException` class.
  * Added a new test method `testRunWithPortConflict` to verify that `PortAlreadyAllocatedException` is thrown when attempting to run a container with a port that is already in use.