### PR TITLE
feat(containers): add methods to retrieve container logs

### DIFF
--- a/src/Containers/ContainerInstance.php
+++ b/src/Containers/ContainerInstance.php
@@ -8,9 +8,23 @@ namespace Testcontainers\Containers;
 interface ContainerInstance
 {
     /**
-         * Get the unique identifier for the container.
-         *
-         * @return string The container ID.
-         */
+     * Get the unique identifier for the container.
+     *
+     * @return string The container ID.
+     */
     public function getContainerId();
+
+    /**
+     * Retrieve the standard output from the container.
+     *
+     * @return string|false The standard output from the container, or false if the container does not exist.
+     */
+    public function getOutput();
+
+    /**
+     * Retrieve the error output from the container.
+     *
+     * @return string|false The error output from the container, or false if the container does not exist.
+     */
+    public function getErrorOutput();
 }

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -46,6 +46,32 @@ class GenericContainerInstance implements ContainerInstance
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getOutput()
+    {
+        if ($this->isRunning() === false) {
+            return false;
+        }
+        $client = DockerClientFactory::create();
+        $output = $client->logs($this->containerId);
+        return $output->getOutput();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorOutput()
+    {
+        if ($this->isRunning() === false) {
+            return false;
+        }
+        $client = DockerClientFactory::create();
+        $output = $client->logs($this->containerId);
+        return $output->getErrorOutput();
+    }
+
+    /**
      * Checks if the container is currently running.
      *
      * @return bool

--- a/src/Docker/DockerLogsOutput.php
+++ b/src/Docker/DockerLogsOutput.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Testcontainers\Docker;
+
+/**
+ * Represents the output of a Docker `logs` command executed via Symfony Process.
+ *
+ * This class extends DockerOutput to provide specific handling for container logs.
+ */
+class DockerLogsOutput extends DockerOutput
+{
+}

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer;
 use Testcontainers\Containers\GenericContainerInstance;
+use Testcontainers\Docker\Exception\NoSuchContainerException;
 
 class GenericContainerInstanceTest extends TestCase
 {
@@ -12,6 +14,38 @@ class GenericContainerInstanceTest extends TestCase
         $instance = new GenericContainerInstance('8188d93d8a27');
 
         $this->assertSame('8188d93d8a27', $instance->getContainerId());
+    }
+
+    public function testGetOutput()
+    {
+        $container = new GenericContainer('nginx:1.27.2');
+        $instance = $container->start();
+
+        $this->assertNotEmpty($instance->getOutput());
+    }
+
+    public function testGetOutputStopsContainer()
+    {
+        $instance = new GenericContainerInstance('8188d93d8a27'); // not exist container id
+        $instance->stop();
+
+        $this->assertFalse($instance->getOutput());
+    }
+
+    public function testGetErrorOutput()
+    {
+        $container = new GenericContainer('nginx:1.27.2');
+        $instance = $container->start();
+
+        $this->assertNotEmpty($instance->getErrorOutput());
+    }
+
+    public function testGetErrorOutputStopsContainer()
+    {
+        $instance = new GenericContainerInstance('8188d93d8a27'); // not exist container id
+        $instance->stop();
+
+        $this->assertFalse($instance->getErrorOutput());
     }
 
     public function testIsRunning()

--- a/tests/Unit/Docker/DockerClientTest.php
+++ b/tests/Unit/Docker/DockerClientTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Docker;
 
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Docker\DockerClient;
+use Testcontainers\Docker\DockerLogsOutput;
 use Testcontainers\Docker\DockerProcessStatusOutput;
 use Testcontainers\Docker\DockerRunOutput;
 use Testcontainers\Docker\DockerRunWithDetachOutput;
@@ -143,5 +144,24 @@ class DockerClientTest extends TestCase
         $this->assertSame(substr($containerId, 0, 12), $status['ID']);
         $this->assertSame('alpine:latest', $status['Image']);
         $this->assertSame('running', $status['State']);
+    }
+
+    public function testLogs()
+    {
+        $client = new DockerClient();
+        $output = $client->run('jpetazzo/clock:latest', null, null, [
+            'detach' => true,
+        ]);
+
+        try {
+            $containerId = $output->getContainerId();
+            $logsOutput = $client->logs($containerId);
+
+            $this->assertInstanceOf(DockerLogsOutput::class, $logsOutput);
+            $this->assertSame(0, $logsOutput->getExitCode());
+            $this->assertNotEmpty($logsOutput->getOutput());
+        } finally {
+            $client->stop($output->getContainerId());
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces new methods for retrieving the standard and error output from Docker containers, along with corresponding tests. The main changes include updates to the `ContainerInstance` interface, implementation in `GenericContainerInstance`, a new method in the `DockerClient`, and the addition of a new class `DockerLogsOutput`.

### Interface and Implementation Updates:
* [`src/Containers/ContainerInstance.php`](diffhunk://#diff-9871ae1df65d02c2a8ec6ca1a21a3e0128f5324edd371a4f83a9759a8e72724fR16-R29): Added `getOutput` and `getErrorOutput` methods to the `ContainerInstance` interface.
* [`src/Containers/GenericContainerInstance.php`](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cR48-R73): Implemented `getOutput` and `getErrorOutput` methods to fetch logs using the Docker client.

### Docker Client Enhancements:
* [`src/Docker/DockerClient.php`](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R357-R395): Introduced `logs` method to retrieve Docker container logs, handling both standard and error outputs.

### New Class for Logs Output:
* [`src/Docker/DockerLogsOutput.php`](diffhunk://#diff-201362d758d8ceaf09c147af58a1db5533eb6bf68f797c658721a3c8b997658fR1-R12): Created a new class `DockerLogsOutput` to represent the output of Docker logs command.

### Unit Tests:
* [`tests/Unit/Containers/GenericContainerInstanceTest.php`](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R19-R50): Added tests for the new `getOutput` and `getErrorOutput` methods in `GenericContainerInstance`.
* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fR148-R166): Added a test for the new `logs` method in `DockerClient`.