### PR TITLE
feat(GenericContainer): introduce HttpWaitStrategy for HTTP endpoint readiness

### DIFF
--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -10,6 +10,7 @@ use Testcontainers\Containers\PortStrategy\PortStrategy;
 use Testcontainers\Containers\PortStrategy\PortStrategyProvider;
 use Testcontainers\Containers\WaitStrategy\AlreadyExistsWaitStrategyException;
 use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
+use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
 use Testcontainers\Containers\WaitStrategy\WaitStrategy;
 use Testcontainers\Containers\WaitStrategy\WaitStrategyProvider;
 use Testcontainers\Docker\DockerClientFactory;
@@ -124,6 +125,7 @@ class GenericContainer implements Container
 
         $this->waitStrategyProvider = new WaitStrategyProvider();
         $this->waitStrategyProvider->register(new HostPortWaitStrategy());
+        $this->waitStrategyProvider->register(new HttpWaitStrategy());
         $this->registerWaitStrategy($this->waitStrategyProvider);
     }
 

--- a/src/Containers/WaitStrategy/HttpProbe.php
+++ b/src/Containers/WaitStrategy/HttpProbe.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy;
+
+interface HttpProbe
+{
+    public function available($endpoint, $responseCode = 200);
+}

--- a/src/Containers/WaitStrategy/HttpProbeGetHeaders.php
+++ b/src/Containers/WaitStrategy/HttpProbeGetHeaders.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy;
+
+class HttpProbeGetHeaders implements HttpProbe
+{
+    public function available($endpoint, $responseCode = 200)
+    {
+        $headers = @get_headers($endpoint);
+        if ($headers === false) {
+            return false;
+        }
+        $statusCode = (int) substr($headers[0], 9, 3);
+        return $statusCode == $responseCode;
+    }
+}

--- a/src/Containers/WaitStrategy/HttpWaitStrategy.php
+++ b/src/Containers/WaitStrategy/HttpWaitStrategy.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy;
+
+/**
+ * HttpWaitStrategy waits until a specified HTTP endpoint is reachable.
+ *
+ * This strategy continuously checks the readiness of the specified HTTP endpoint
+ * until it is reachable or a timeout occurs.
+ */
+class HttpWaitStrategy implements WaitStrategy
+{
+    /**
+     * The HTTP probe used to check the availability of the endpoint.
+     *
+     * @var HttpProbe
+     */
+    private $probe;
+
+    /**
+     * The endpoint URL to be checked for readiness.
+     *
+     * This can be a full URL or null. If null, the endpoint will be constructed
+     * using the schema, host, port, and path properties.
+     *
+     * @var string|null
+     */
+    private $endpoint;
+
+    /**
+     * The schema (protocol) to be used in the endpoint URL (e.g., 'http' or 'https').
+     *
+     * If not set, the default value 'http' will be used.
+     *
+     * @var string|null
+     */
+    private $schema;
+
+    /**
+     * The host to be used in the endpoint URL.
+     *
+     * If not set, the default value 'localhost' will be used.
+     *
+     * @var string|null
+     */
+    private $host;
+
+    /**
+     * The path to be used in the endpoint URL.
+     *
+     * If not set, the default value '/' will be used.
+     *
+     * @var string|null The path to be used in the endpoint URL, or null if not set.
+     */
+    private $path;
+
+    /**
+    * The port to be used in the endpoint URL.
+    *
+    * If not set, the port will be determined dynamically based on the container's exposed ports.
+    *
+    * @var int|null The port number, or null if not set.
+    */
+    private $port;
+
+    /**
+     * The expected HTTP response code for the endpoint.
+     *
+     * @var int
+     */
+    private $expectedResponseCode = 200;
+
+    /**
+     * The timeout duration in seconds for waiting until the container instance is ready.
+     *
+     * This value determines how long the strategy will wait for the container to become ready
+     * before throwing a timeout exception. The default is 30 seconds.
+     *
+     * @var int The timeout duration in seconds.
+     */
+    private $timeout = 30;
+
+    public function __construct($probe = null)
+    {
+        $this->probe = $probe ?: new HttpProbeGetHeaders();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function waitUntilReady($instance)
+    {
+        $now = time();
+        $endpoint = $this->endpoint;
+        if ($endpoint === null) {
+            $schema = $this->schema ?: 'http';
+            $host = $this->host ?: $instance->getHost();
+            $port = $this->port ?: $instance->getMappedPort($instance->getExposedPorts()[0]);
+            $path = $this->path ?: '/';
+            $endpoint = sprintf('%s://%s:%s%s', $schema, $host, $port, $path);
+        }
+
+        while (1) {
+            if (time() - $now > $this->timeout) {
+                throw new WaitingTimeoutException($this->timeout);
+            }
+            if ($this->probe->available($endpoint, $this->expectedResponseCode)) {
+                break;
+            }
+            usleep(100);
+        }
+    }
+
+    /**
+     * Sets the endpoint to be checked for readiness.
+     *
+     * @param string $endpoint The endpoint to be checked.
+     * @return $this
+     */
+    public function withEndpoint($endpoint)
+    {
+        $this->endpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * Sets the schema to be used in the endpoint URL.
+     *
+     * @param string $schema The schema to be used.
+     * @return $this
+     */
+    public function withSchema($schema)
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Sets the host to be used in the endpoint URL.
+     *
+     * @param string $host The host to be used.
+     * @return $this
+     */
+    public function withHost($host)
+    {
+        $this->host = $host;
+
+        return $this;
+    }
+
+    /**
+     * Sets the path to be used in the endpoint URL.
+     *
+     * @param string $path The path to be used.
+     * @return $this
+     */
+    public function withPath($path)
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * Sets the port to be used in the endpoint URL.
+     *
+     * @param int $port The port to be used.
+     * @return $this
+     */
+    public function withPort($port)
+    {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    /**
+     * Sets the expected HTTP response code for the endpoint.
+     *
+     * @param int $responseCode The expected HTTP response code.
+     * @return $this
+     */
+    public function withExpectedResponseCode($responseCode)
+    {
+        $this->expectedResponseCode = $responseCode;
+
+        return $this;
+    }
+
+    /**
+     * Sets the timeout duration for waiting until the container instance is ready.
+     *
+     * @param int $seconds The number of seconds to wait before timing out.
+     * @return $this The current instance for method chaining.
+     */
+    public function withTimeoutSeconds($seconds)
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'http';
+    }
+}

--- a/tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit\Containers\WaitStrategy;
+
+use Testcontainers\Containers\GenericContainerInstance;
+use Testcontainers\Containers\WaitStrategy\HttpProbe;
+use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
+
+class HttpWaitStrategyTest extends WaitStrategyTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function resolveWaitStrategy()
+    {
+        return new HttpWaitStrategy();
+    }
+
+    public function testWaitUntilReady()
+    {
+        $instance = new GenericContainerInstance('8188d93d8a27', [
+            'ports' => [80 => 8239],
+        ]);
+        $probe = $this->createMock(HttpProbe::class);
+        $probe->method('available')
+            ->willReturnOnConsecutiveCalls(false, false, true);
+        $strategy = new HttpWaitStrategy($probe);
+        $strategy->waitUntilReady($instance);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new HTTP-based wait strategy for container readiness checks. The main changes include the addition of a new `HttpWaitStrategy` class, an interface for HTTP probes, and a concrete implementation of this interface for checking HTTP headers. Additionally, a unit test for the new wait strategy has been added.

### Introduction of HTTP-based wait strategy:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R13): Added `HttpWaitStrategy` to the list of wait strategies registered in the constructor. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R13) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R128)
* [`src/Containers/WaitStrategy/HttpWaitStrategy.php`](diffhunk://#diff-e82e53f4f7540d6e7e0daee75c4b9045e11ac60df33b97aa443f8fd8854d1a79R1-R212): Created the `HttpWaitStrategy` class to wait until a specified HTTP endpoint is reachable.

### HTTP probe interface and implementation:

* [`src/Containers/WaitStrategy/HttpProbe.php`](diffhunk://#diff-70aaf24851cd3002b97104631e32a038123bd8e1caa0f1d7e9e604c334259327R1-R8): Added the `HttpProbe` interface for checking the availability of an HTTP endpoint.
* [`src/Containers/WaitStrategy/HttpProbeGetHeaders.php`](diffhunk://#diff-69759918f47dbd4e31a8b73c7c3a1d737cc6a90988a79e3bb70341d2b4a8bcdeR1-R16): Implemented the `HttpProbe` interface with the `HttpProbeGetHeaders` class, which checks HTTP headers to determine endpoint availability.

### Unit testing:

* [`tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php`](diffhunk://#diff-1eed85d1aee706cfc970731521c6d1447bf7af7fc243552f39bbc5290b6ce874R1-R33): Added unit tests for the `HttpWaitStrategy` class to ensure it correctly waits until the HTTP endpoint is ready.