### PR TITLE
feat: add PDO-based wait strategies and DSN implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "k-kinzal/testcontainers-php",
+    "description": "PHP library for Testcontainers",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -24,6 +25,7 @@
     "require": {
         "php": "~5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1 || ~8.2 || ~8.3",
         "ext-json": "*",
+        "ext-pdo": "*",
         "symfony/process": "*"
     },
     "require-dev": {

--- a/src/Containers/WaitStrategy/PDO/DSN.php
+++ b/src/Containers/WaitStrategy/PDO/DSN.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy\PDO;
+
+/**
+ * DSN interface for defining Data Source Name components.
+ */
+interface DSN
+{
+    /**
+     * Set the host for the DSN.
+     *
+     * @param string $host The hostname to set.
+     * @return $this
+     */
+    public function withHost($host);
+
+    /**
+     * Set the port for the DSN.
+     *
+     * @param int $port The port to set.
+     * @return $this
+     */
+    public function withPort($port);
+
+    /**
+     * Convert the DSN to a string representation.
+     *
+     * @return string The string representation of the DSN.
+     */
+    public function toString();
+
+    public function __toString();
+}

--- a/src/Containers/WaitStrategy/PDO/MySQLDSN.php
+++ b/src/Containers/WaitStrategy/PDO/MySQLDSN.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy\PDO;
+
+use LogicException;
+
+/**
+ * MySQLDSN provides a way to define a MySQL Data Source Name (DSN).
+ * It allows setting the host, port, database name, and character set for the DSN.
+ *
+ * @see https://www.php.net/manual/en/ref.pdo-mysql.connection.php
+ */
+class MySQLDSN implements DSN
+{
+    /**
+     * The hostname for the DSN.
+     *
+     * @var string|null
+     */
+    private $host;
+
+    /**
+     * The port number for the DSN.
+     *
+     * @var int|null
+     */
+    private $port;
+
+    /**
+     * The name of the database.
+     *
+     * @var string|null
+     */
+    private $dbname;
+
+
+    /**
+     * The character set to use for the DSN.
+     *
+     * @var string|null
+     */
+    private $charset;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withHost($host)
+    {
+        $this->host = $host;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withPort($port)
+    {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    /**
+     * Set the database name for the DSN.
+     *
+     * @param string $dbname The name of the database.
+     * @return $this
+     */
+    public function withDbname($dbname)
+    {
+        $this->dbname = $dbname;
+
+        return $this;
+    }
+
+    /**
+     * Set the character set for the DSN.
+     *
+     * @param string $charset The character set to use.
+     * @return $this
+     */
+    public function withCharset($charset)
+    {
+        $this->charset = $charset;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toString()
+    {
+        if ($this->host === null) {
+            throw new LogicException('Host is required');
+        }
+        $dsn = sprintf('mysql:host=%s;', $this->host);
+        if ($this->port !== null) {
+            $dsn .= 'port=' . $this->port . ';';
+        }
+        if ($this->dbname !== null) {
+            $dsn .= 'dbname=' . $this->dbname . ';';
+        }
+        if ($this->charset !== null) {
+            $dsn .= 'charset=' . $this->charset . ';';
+        }
+        return $dsn;
+    }
+
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php
+++ b/src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy\PDO;
+
+use LogicException;
+use PDO;
+use PDOException;
+use Testcontainers\Containers\WaitStrategy\WaitingTimeoutException;
+use Testcontainers\Containers\WaitStrategy\WaitStrategy;
+
+/**
+ * PDOConnectWaitStrategy ensures that a PDO connection is established before proceeding.
+ * This strategy continuously checks the readiness of the PDO connection until it is successfully established or a timeout occurs.
+ *
+ * Note: Do not use this strategy in PHP 5.6 as it may cause a Fatal error due to memory leaks.
+ */
+class PDOConnectWaitStrategy implements WaitStrategy
+{
+    /**
+     * The DSN (Data Source Name) for the PDO connection.
+     *
+     * This property holds the DSN instance, which contains the connection details
+     * such as host, port, and database name. It can be null if not set.
+     *
+     * @var DSN|null
+     */
+    private $dsn;
+
+    /**
+     * The username for the PDO connection.
+     *
+     * This property holds the username used to authenticate the PDO connection.
+     *
+     * @var string|null
+     */
+    private $username;
+
+    /**
+     * The password for the PDO connection.
+     *
+     * This property holds the password used to authenticate the PDO connection.
+     *
+     * @var string|null
+     */
+    private $password;
+
+    /**
+     * Timeout duration in seconds for waiting until the container instance is ready.
+     *
+     * @var int
+     */
+    private $timeout = 30;
+
+    /**
+     * The interval duration between each retry attempt in microseconds.
+     *
+     * This property defines how long the wait strategy should pause between each retry
+     * when checking if the container is ready. The interval is specified in microseconds.
+     *
+     * @var int The retry interval in microseconds.
+     */
+    private $retryInterval = 100;
+
+    /**
+     * @inheritDoc
+     *
+     * @throws WaitingTimeoutException If the timeout duration is exceeded.
+     */
+    public function waitUntilReady($instance)
+    {
+        if ($this->dsn === null) {
+            throw new LogicException('The DSN for the PDO connection is not set');
+        }
+
+        $now = time();
+
+        $host = str_replace('localhost', '127.0.0.1', $instance->getHost());
+        $ports = $instance->getExposedPorts();
+        if (count($ports) !== 1) {
+            throw new LogicException('PDOConnectWaitStrategy requires exactly one exposed port: ' . count($ports) . ' exposed');
+        }
+        $port = $instance->getMappedPort($ports[0]);
+
+        $dsn = clone $this->dsn;
+        $dsn = $dsn
+            ->withHost($host)
+            ->withPort($port);
+        while (1) {
+            if (time() - $now > $this->timeout) {
+                throw new WaitingTimeoutException($this->timeout);
+            }
+            try {
+                $pdo = new PDO($dsn->toString(), $this->username, $this->password, [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_TIMEOUT => 1,
+                ]);
+                $pdo->query('SELECT 1');
+                $pdo = null;
+
+                break;
+            } catch (PDOException $e) {
+                // Do nothing
+            }
+            usleep($this->retryInterval);
+        }
+    }
+
+    /**
+     * Specify the DSN (Data Source Name) for the PDO connection.
+     *
+     * This method sets the DSN for the PDO connection, allowing you to define
+     * the connection details such as host, port, and database name.
+     *
+     * @param DSN $dsn The DSN instance containing connection details.
+     * @return $this
+     */
+    public function withDsn(DSN $dsn)
+    {
+        $this->dsn = $dsn;
+
+        return $this;
+    }
+
+    /**
+     * Set the username for the PDO connection.
+     *
+     * This method sets the username used to authenticate the PDO connection.
+     *
+     * @param string $username The username for the PDO connection.
+     * @return $this
+     */
+    public function withUsername($username)
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * Specify the password for the PDO connection.
+     *
+     * This method sets the password used to authenticate the PDO connection.
+     *
+     * @param string $password The password for the PDO connection.
+     * @return $this
+     */
+    public function withPassword($password)
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * Set the timeout duration for waiting until the container instance is ready.
+     *
+     * This method allows you to specify how long (in seconds) the wait strategy should wait
+     * for the container to be ready before timing out.
+     *
+     * @param int $timeout The timeout duration in seconds.
+     * @return $this
+     */
+    public function withTimeoutSeconds($timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Set the interval duration between each retry in microseconds.
+     *
+     * This method allows you to specify the interval duration between each retry
+     * when waiting for the container to be ready. The interval is defined in microseconds.
+     *
+     * @param int $interval The interval duration in microseconds.
+     * @return $this
+     */
+    public function withRetryInterval($interval)
+    {
+        $this->retryInterval = $interval;
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getName()
+    {
+        return 'pdo_connect';
+    }
+}

--- a/src/Containers/WaitStrategy/PDO/SQLiteDSN.php
+++ b/src/Containers/WaitStrategy/PDO/SQLiteDSN.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Testcontainers\Containers\WaitStrategy\PDO;
+
+class SQLiteDSN implements DSN
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function withHost($host)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withPort($port)
+    {
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toString()
+    {
+        // TODO: support file path
+        return 'sqlite::memory:';
+    }
+
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/tests/Unit/Containers/WaitStrategy/PDO/DSNTestCase.php
+++ b/tests/Unit/Containers/WaitStrategy/PDO/DSNTestCase.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Containers\WaitStrategy\PDO;
+
+use PDO;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\WaitStrategy\PDO\DSN;
+
+abstract class DSNTestCase extends TestCase
+{
+    /**
+     * @return DSN
+     */
+    abstract public function resolveDSN();
+
+    public function testWithHost()
+    {
+        $hostname = 'localhost';
+        $dsn = $this->resolveDSN()->withHost($hostname);
+
+        $this->assertTrue(strpos($dsn->toString(), $hostname) !== false);
+    }
+
+    public function testWithPort()
+    {
+        $port = 3306;
+        $dsn = $this->resolveDSN()
+            ->withHost('localhost')
+            ->withPort($port);
+
+        $this->assertTrue(strpos($dsn->toString(), (string) $port) !== false);
+    }
+
+    public function testPassPDO()
+    {
+        $dsn = $this->resolveDSN()
+            ->withHost('localhost')
+            ->withPort(3306);
+
+        try {
+            new PDO($dsn->toString());
+        } catch (PDOException $e) {
+            if ($e->getMessage() === 'could not find driver') {
+                throw $e;
+            }
+        }
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Unit/Containers/WaitStrategy/PDO/MySQLDSNTest.php
+++ b/tests/Unit/Containers/WaitStrategy/PDO/MySQLDSNTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Containers\WaitStrategy\PDO;
+
+use Testcontainers\Containers\WaitStrategy\PDO\MySQLDSN;
+
+class MySQLDSNTest extends DSNTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function resolveDSN()
+    {
+        return new MySQLDSN();
+    }
+
+    public function testWithDbname()
+    {
+        $dbname = 'test';
+        $dsn = $this->resolveDSN()
+            ->withHost('localhost')
+            ->withDbname($dbname);
+
+        $this->assertTrue(strpos($dsn->toString(), $dbname) !== false);
+    }
+
+    public function testWithCharset()
+    {
+        $charset = 'utf8';
+        $dsn = $this->resolveDSN()
+            ->withHost('localhost')
+            ->withCharset($charset);
+
+        $this->assertTrue(strpos($dsn->toString(), $charset) !== false);
+    }
+
+    public function testFullDSN()
+    {
+        $dsn = $this->resolveDSN()
+            ->withHost('localhost')
+            ->withPort(3306)
+            ->withDbname('test')
+            ->withCharset('utf8');
+
+        $this->assertEquals('mysql:host=localhost;port=3306;dbname=test;charset=utf8;', $dsn->toString());
+    }
+}

--- a/tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\Containers\WaitStrategy\PDO;
+
+use LogicException;
+use Testcontainers\Containers\GenericContainerInstance;
+use Testcontainers\Containers\WaitStrategy\PDO\PDOConnectWaitStrategy;
+use Testcontainers\Containers\WaitStrategy\PDO\SQLiteDSN;
+use Tests\Unit\Containers\WaitStrategy\WaitStrategyTestCase;
+
+class PDOConnectWaitStrategyTest extends WaitStrategyTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function resolveWaitStrategy()
+    {
+        return (new PDOConnectWaitStrategy())
+            ->withDsn(new SQLiteDSN());
+    }
+
+    public function testWaitUntilReady()
+    {
+        $instance = new GenericContainerInstance('818b7f3b1b3b', [
+            'ports' => [3306 => 3306],
+        ]);
+        $strategy = $this->resolveWaitStrategy();
+        $strategy->waitUntilReady($instance);
+
+        $this->assertTrue(true);
+    }
+
+    public function testWaitUntilReadyNotSetDSN()
+    {
+        $this->expectException(LogicException::class);
+
+        $instance = new GenericContainerInstance('818b7f3b1b3b', [
+            'ports' => [3306 => 3306],
+        ]);
+        $strategy = new PDOConnectWaitStrategy();
+        $strategy->waitUntilReady($instance);
+    }
+
+    public function testWaitUntilReadyNotSetPort()
+    {
+        $this->expectException(LogicException::class);
+
+        $instance = new GenericContainerInstance('818b7f3b1b3b');
+        $strategy = $this->resolveWaitStrategy();
+        $strategy->waitUntilReady($instance);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for handling PDO connections in the `Testcontainers` PHP library. The changes include adding new classes for DSN handling, a wait strategy for PDO connections, and corresponding unit tests.

### New feature: PDO connection handling

#### DSN Handling
* Added `DSN` interface for defining Data Source Name components (`src/Containers/WaitStrategy/PDO/DSN.php`).
* Added `MySQLDSN` class implementing `DSN` for MySQL connections (`src/Containers/WaitStrategy/PDO/MySQLDSN.php`).
* Added `SQLiteDSN` class implementing `DSN` for SQLite connections (`src/Containers/WaitStrategy/PDO/SQLiteDSN.php`).

#### Wait Strategy
* Added `PDOConnectWaitStrategy` class to ensure PDO connection readiness before proceeding (`src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php`).

#### Unit Tests
* Added `DSNTestCase` abstract class for DSN-related tests (`tests/Unit/Containers/WaitStrategy/PDO/DSNTestCase.php`).
* Added `MySQLDSNTest` class for testing `MySQLDSN` functionality (`tests/Unit/Containers/WaitStrategy/PDO/MySQLDSNTest.php`).
* Added `PDOConnectWaitStrategyTest` class for testing `PDOConnectWaitStrategy` functionality (`tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php`).

#### Miscellaneous
* Updated `composer.json` to include `ext-pdo` as a requirement and added a description for the package (`composer.json`). [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R3) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R28)