### PR TITLE
fix(docker): enhance error message with stderr output

### DIFF
--- a/src/Docker/Exception/DockerException.php
+++ b/src/Docker/Exception/DockerException.php
@@ -28,7 +28,12 @@ class DockerException extends RuntimeException
         $command = $process->getCommandLine();
         $exitCode = $process->getExitCode();
         parent::__construct(
-            "Failed to docker command: `$command`, exit code: `$exitCode`"
+            sprintf(
+                "Failed to docker command: `%s`, exit code: `%s`, stderr: %s",
+                $command,
+                $exitCode,
+                $process->getErrorOutput()
+            )
         );
 
         $this->process = $process;


### PR DESCRIPTION
This pull request includes a change to the error message formatting in the `DockerException` class constructor to provide more detailed information about the error.

Error message improvement:

* [`src/Docker/Exception/DockerException.php`](diffhunk://#diff-34e51d58d5b8b01705a7296ffdeb011befa9f4fb351014360d5c3acc1ddedafdL31-R36): Enhanced the error message in the constructor to include the standard error output (`stderr`) of the process.