### PR TITLE
feat(containers): add support for privileged mode in container instances

### DIFF
--- a/src/Containers/ContainerInstance.php
+++ b/src/Containers/ContainerInstance.php
@@ -37,6 +37,13 @@ interface ContainerInstance
     public function getMappedPort($exposedPort);
 
     /**
+     * Get the privileged mode status of the container.
+     *
+     * @return bool True if the container is running in privileged mode, false otherwise.
+     */
+    public function getPrivilegedMode();
+
+    /**
      * Retrieve the standard output from the container.
      *
      * @return string The standard output from the container.

--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -72,6 +72,20 @@ class GenericContainer implements Container
     private $env = [];
 
     /**
+     * Define the default privileged mode to be used for the container.
+     *
+     * @var bool|null
+     */
+    protected static $PRIVILEGED;
+
+    /**
+     * The privileged mode to be used for the container.
+     *
+     * @var bool
+     */
+    private $privileged = false;
+
+    /**
      * Define the default port strategy to be used for the container.
      * @var string|null
      */
@@ -280,7 +294,9 @@ class GenericContainer implements Container
      */
     public function withPrivilegedMode($mode)
     {
-        // TODO: Implement withPrivilegedMode() method.
+        $this->privileged = $mode;
+
+        return $this;
     }
 
     /**
@@ -369,6 +385,23 @@ class GenericContainer implements Container
             return $this->env;
         }
         return null;
+    }
+
+    /**
+     * Retrieve the privileged mode for the container.
+     *
+     * This method returns whether the container should run in privileged mode.
+     * If a specific privileged mode is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default privileged mode from the provider.
+     *
+     * @return bool True if the container should run in privileged mode, false otherwise.
+     */
+    protected function privileged()
+    {
+        if (static::$PRIVILEGED) {
+            return static::$PRIVILEGED;
+        }
+        return $this->privileged;
     }
 
     /**
@@ -474,6 +507,7 @@ class GenericContainer implements Container
                 'detach' => true,
                 'env' => $this->env(),
                 'publish' => $ports,
+                'privileged' => $this->privileged(),
             ]);
         } catch (PortAlreadyAllocatedException $e) {
             $behavior = $portStrategy->conflictBehavior();
@@ -502,6 +536,7 @@ class GenericContainer implements Container
                 return $carry;
             }, []),
             'env' => $this->env(),
+            'privileged' => $this->privileged(),
         ];
         $instance = new GenericContainerInstance($containerId, $containerDef);
 

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -111,6 +111,14 @@ class GenericContainerInstance implements ContainerInstance
     /**
      * {@inheritdoc}
      */
+    public function getPrivilegedMode()
+    {
+        return isset($this->containerDef['privileged']) ? $this->containerDef['privileged'] : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getOutput()
     {
         $client = DockerClientFactory::create();

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -34,6 +34,15 @@ class GenericContainerInstanceTest extends TestCase
         $this->assertSame(8080, $instance->getMappedPort(80));
     }
 
+    public function testGetPrivilegedMode()
+    {
+        $instance = new GenericContainerInstance('8188d93d8a27', [
+            'privileged' => true,
+        ]);
+
+        $this->assertTrue($instance->getPrivilegedMode());
+    }
+
     public function testGetOutput()
     {
         $container = (new GenericContainer('alpine:latest'))

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\GenericContainer;
 use Testcontainers\Containers\PortStrategy\LocalRandomPortStrategy;
+use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
 class GenericContainerTest extends TestCase
 {
@@ -99,5 +100,15 @@ class GenericContainerTest extends TestCase
         $this->assertTrue(is_int($instance->getMappedPort(443)));
         $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(443));
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
+    }
+
+    public function testWithPrivilegedMode()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withPrivilegedMode(true)
+            ->withCommands(['tail', '-f', '/dev/null']);
+        $instance = $container->start();
+
+        $this->assertSame(true, $instance->getPrivilegedMode());
     }
 }


### PR DESCRIPTION
### **User description**
This pull request introduces the capability to manage privileged mode for containers. The changes include new methods and properties to handle privileged mode, as well as corresponding tests to ensure the functionality works as expected.

### New Features:
* **Privileged Mode Management:**
  * Added a method `getPrivilegedMode` to the `ContainerInstance` interface to retrieve the privileged mode status of a container. (`src/Containers/ContainerInstance.php`)
  * Introduced properties and methods in `GenericContainer` to set and retrieve privileged mode, including a new method `withPrivilegedMode` to configure the container's privileged mode. (`src/Containers/GenericContainer.php`) [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R74-R87) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L283-R299) [[3]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R390-R406)
  * Updated the `start` method to include the privileged mode in the container definition. (`src/Containers/GenericContainer.php`) [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R510) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R539)
  * Implemented the `getPrivilegedMode` method in `GenericContainerInstance` to return the privileged status from the container definition. (`src/Containers/GenericContainerInstance.php`)

### Tests:
* **Unit Tests for Privileged Mode:**
  * Added a test `testGetPrivilegedMode` to verify the retrieval of privileged mode in `GenericContainerInstanceTest`. (`tests/Unit/Containers/GenericContainerInstanceTest.php`)
  * Added a test `testWithPrivilegedMode` to ensure the `GenericContainer` can be configured with privileged mode and that it starts correctly with this configuration. (`tests/Unit/Containers/GenericContainerTest.php`)
  * Imported `LogMessageWaitStrategy` in `GenericContainerTest` to support the new tests. (`tests/Unit/Containers/GenericContainerTest.php`)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced support for managing privileged mode in container instances, allowing containers to run with elevated privileges.
- Added `getPrivilegedMode` method to `ContainerInstance` and `GenericContainerInstance` for retrieving privileged mode status.
- Implemented `withPrivilegedMode` method in `GenericContainer` to configure privileged mode.
- Updated `start` method in `GenericContainer` to include privileged mode in the container definition.
- Added unit tests for `getPrivilegedMode` and `withPrivilegedMode` methods to ensure functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContainerInstance.php</strong><dd><code>Add method to get container privileged mode status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Containers/ContainerInstance.php

<li>Added <code>getPrivilegedMode</code> method to retrieve container's privileged mode <br>status.<br>


</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/13/files#diff-9871ae1df65d02c2a8ec6ca1a21a3e0128f5324edd371a4f83a9759a8e72724f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenericContainer.php</strong><dd><code>Implement privileged mode management in GenericContainer</code>&nbsp; </dd></summary>
<hr>

src/Containers/GenericContainer.php

<li>Introduced <code>privileged</code> property and methods to manage privileged mode.<br> <li> Updated <code>start</code> method to include privileged mode in container <br>definition.<br>


</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/13/files#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1">+36/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenericContainerInstance.php</strong><dd><code>Implement privileged mode retrieval in GenericContainerInstance</code></dd></summary>
<hr>

src/Containers/GenericContainerInstance.php

<li>Implemented <code>getPrivilegedMode</code> to return privileged status from <br>container definition.<br>


</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/13/files#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GenericContainerInstanceTest.php</strong><dd><code>Add unit test for privileged mode retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/Containers/GenericContainerInstanceTest.php

- Added unit test for `getPrivilegedMode` method.



</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/13/files#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenericContainerTest.php</strong><dd><code>Add unit test for setting privileged mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/Containers/GenericContainerTest.php

- Added unit test for `withPrivilegedMode` method.



</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/13/files#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information