### PR TITLE
feat(containers): add label management to container instances

### DIFF
--- a/src/Containers/ContainerInstance.php
+++ b/src/Containers/ContainerInstance.php
@@ -15,6 +15,21 @@ interface ContainerInstance
     public function getContainerId();
 
     /**
+     * Get the label of the container.
+     *
+     * @param string $label
+     * @return string|null
+     */
+    public function getLabel($label);
+
+    /**
+     * Get the labels of the container.
+     *
+     * @return array<string, string>
+     */
+    public function getLabels();
+
+    /**
      * Get the host address of the container.
      *
      * @return string The host address of the container.

--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -72,6 +72,18 @@ class GenericContainer implements Container
     private $env = [];
 
     /**
+     * Define the default labels to be used for the container.
+     * @var array<string, string>|null
+     */
+    protected static $LABELS;
+
+    /**
+     * The labels to be used for the container.
+     * @var array<string, string>
+     */
+    private $labels = [];
+
+    /**
      * Define the default privileged mode to be used for the container.
      *
      * @var bool|null
@@ -218,7 +230,9 @@ class GenericContainer implements Container
      */
     public function withLabels($labels)
     {
-        // TODO: Implement withLabels() method.
+        $this->labels = $labels;
+
+        return $this;
     }
 
     /**
@@ -388,6 +402,26 @@ class GenericContainer implements Container
     }
 
     /**
+     * Retrieve the labels for the container.
+     *
+     * This method returns the labels that should be used for the container.
+     * If specific labels are set, it will return those. Otherwise, it will
+     * attempt to retrieve the default labels from the provider.
+     *
+     * @return array<string, string>|null The labels to be used, or null if none are set.
+     */
+    protected function labels()
+    {
+        if (static::$LABELS) {
+            return static::$LABELS;
+        }
+        if ($this->labels) {
+            return $this->labels;
+        }
+        return null;
+    }
+
+    /**
      * Retrieve the privileged mode for the container.
      *
      * This method returns whether the container should run in privileged mode.
@@ -506,10 +540,14 @@ class GenericContainer implements Container
             $output = $client->run($this->image, $command, $args, [
                 'detach' => true,
                 'env' => $this->env(),
+                'label' => $this->labels(),
                 'publish' => $ports,
                 'privileged' => $this->privileged(),
             ]);
         } catch (PortAlreadyAllocatedException $e) {
+            if ($portStrategy === null) {
+                throw $e;
+            }
             $behavior = $portStrategy->conflictBehavior();
             if ($behavior->isRetry()) {
                 return $this->start();
@@ -530,12 +568,13 @@ class GenericContainer implements Container
             'image' => $this->image,
             'command' => $command,
             'args' => $args,
+            'env' => $this->env(),
+            'labels' => $this->labels(),
             'ports' => array_reduce($ports, function ($carry, $item) {
                 $parts = explode(':', $item);
                 $carry[(int)$parts[1]] = (int)$parts[0];
                 return $carry;
             }, []),
-            'env' => $this->env(),
             'privileged' => $this->privileged(),
         ];
         $instance = new GenericContainerInstance($containerId, $containerDef);

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -71,6 +71,37 @@ class GenericContainerInstance implements ContainerInstance
     /**
      * {@inheritdoc}
      */
+    public function getLabel($label)
+    {
+        if (!isset($this->containerDef['labels'])) {
+            return null;
+        }
+        if (!is_array($this->containerDef['labels'])) {
+            return null;
+        }
+        if (!isset($this->containerDef['labels'][$label])) {
+            return null;
+        }
+        return $this->containerDef['labels'][$label];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLabels()
+    {
+        if (!isset($this->containerDef['labels'])) {
+            return [];
+        }
+        if (!is_array($this->containerDef['labels'])) {
+            return [];
+        }
+        return $this->containerDef['labels'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getHost()
     {
         // TODO: Support for host name resolution from remote hosts and from within containers

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -16,6 +16,28 @@ class GenericContainerInstanceTest extends TestCase
         $this->assertSame('8188d93d8a27', $instance->getContainerId());
     }
 
+    public function testGetLabel()
+    {
+        $instance = new GenericContainerInstance('8188d93d8a27', [
+            'labels' => [
+                'com.example.label' => 'value',
+            ],
+        ]);
+
+        $this->assertSame('value', $instance->getLabel('com.example.label'));
+    }
+
+    public function testGetLabels()
+    {
+        $instance = new GenericContainerInstance('8188d93d8a27', [
+            'labels' => [
+                'com.example.label' => 'value',
+            ],
+        ]);
+
+        $this->assertSame(['com.example.label' => 'value'], $instance->getLabels());
+    }
+
     public function testGetHost()
     {
         $instance = new GenericContainerInstance('8188d93d8a27');

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -73,7 +73,21 @@ class GenericContainerTest extends TestCase
         $this->assertSame("VALUE2\n", $instance->getOutput());
     }
 
-    public function testWithExposedPorts()
+    public function testStartWIthLabels()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
+            ->withCommands(['echo', 'Hello, World!']);
+        $instance = $container->start();
+
+        while ($instance->isRunning()) {
+            usleep(100);
+        }
+
+        $this->assertSame("Hello, World!\n", $instance->getOutput());
+    }
+
+    public function testStartWithExposedPorts()
     {
         $container = (new GenericContainer('nginx:latest'))
             ->withExposedPorts(80)
@@ -86,7 +100,7 @@ class GenericContainerTest extends TestCase
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(80));
     }
 
-    public function testWithExposedPortsMultiple()
+    public function testStartWithExposedPortsMultiple()
     {
         $container = (new GenericContainer('nginx:latest'))
             ->withExposedPorts([80, 443])
@@ -102,7 +116,7 @@ class GenericContainerTest extends TestCase
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
     }
 
-    public function testWithPrivilegedMode()
+    public function testStartWithPrivilegedMode()
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withPrivilegedMode(true)


### PR DESCRIPTION
This pull request introduces new functionality to handle container labels in the `Containers` module. The most important changes include adding methods to manage labels in the `ContainerInstance` interface, implementing these methods in `GenericContainer`, and updating the associated tests.

### New functionality for container labels:

* [`src/Containers/ContainerInstance.php`](diffhunk://#diff-9871ae1df65d02c2a8ec6ca1a21a3e0128f5324edd371a4f83a9759a8e72724fR17-R31): Added `getLabel` and `getLabels` methods to the `ContainerInstance` interface.
* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R74-R85): Implemented the `withLabels` method and added properties and methods to manage container labels, including `labels` and `LABELS`. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R74-R85) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L221-R235) [[3]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R404-R423) [[4]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R543-R550) [[5]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R571-L538)
* [`src/Containers/GenericContainerInstance.php`](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cR71-R101): Implemented the `getLabel` and `getLabels` methods.

### Tests for new label functionality:

* [`tests/Unit/Containers/GenericContainerInstanceTest.php`](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R19-R40): Added tests for `getLabel` and `getLabels` methods.
* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L76-R90): Added a test for starting a container with labels. Updated test names for consistency. [[1]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L76-R90) [[2]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L89-R103) [[3]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L105-R119)