### PR TITLE
feat(containers): add support for setting and retrieving workin…

### DIFF
--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -84,6 +84,18 @@ class GenericContainer implements Container
     private $labels = [];
 
     /**
+     * Define the default working directory to be used for the container.
+     * @var string|null
+     */
+    protected static $WORKDIR;
+
+    /**
+     * The working directory to be used for the container.
+     * @var string|null
+     */
+    private $workDir;
+
+    /**
      * Define the default privileged mode to be used for the container.
      *
      * @var bool|null
@@ -294,7 +306,9 @@ class GenericContainer implements Container
      */
     public function withWorkingDirectory($workDir)
     {
-        // TODO: Implement withWorkingDirectory() method.
+        $this->workDir = $workDir;
+
+        return $this;
     }
 
     /**
@@ -424,6 +438,19 @@ class GenericContainer implements Container
     }
 
     /**
+     * Retrieve the working directory for the container.
+     *
+     * @return string|null
+     */
+    protected function workDir()
+    {
+        if (static::$WORKDIR) {
+            return static::$WORKDIR;
+        }
+        return $this->workDir;
+    }
+
+    /**
      * Retrieve the privileged mode for the container.
      *
      * This method returns whether the container should run in privileged mode.
@@ -544,6 +571,7 @@ class GenericContainer implements Container
                 'env' => $this->env(),
                 'label' => $this->labels(),
                 'publish' => $ports,
+                'workdir' => $this->workDir(),
                 'privileged' => $this->privileged(),
             ]);
         } catch (PortAlreadyAllocatedException $e) {
@@ -577,6 +605,7 @@ class GenericContainer implements Container
                 $carry[(int)$parts[1]] = (int)$parts[0];
                 return $carry;
             }, []),
+            'workdir' => $this->workDir(),
             'privileged' => $this->privileged(),
         ];
         $instance = new GenericContainerInstance($containerId, $containerDef);

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -73,7 +73,7 @@ class GenericContainerTest extends TestCase
         $this->assertSame("VALUE2\n", $instance->getOutput());
     }
 
-    public function testStartWIthLabels()
+    public function testStartWithLabels()
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
@@ -114,6 +114,20 @@ class GenericContainerTest extends TestCase
         $this->assertTrue(is_int($instance->getMappedPort(443)));
         $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(443));
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
+    }
+
+    public function testStartWithWorkingDirectory()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withWorkingDirectory('/tmp')
+            ->withCommands(['pwd']);
+        $instance = $container->start();
+
+        while ($instance->isRunning()) {
+            usleep(100);
+        }
+
+        $this->assertSame("/tmp\n", $instance->getOutput());
     }
 
     public function testStartWithPrivilegedMode()


### PR DESCRIPTION
### **User description**
This pull request introduces functionality to set and retrieve the working directory for the `GenericContainer` class, along with corresponding tests. The changes ensure that the working directory can be defined, used, and tested effectively.

### Enhancements to `GenericContainer` class:

* Added a protected static property `WORKDIR` and a private property `workDir` to define the default and instance-specific working directories, respectively.
* Implemented the `withWorkingDirectory` method to set the working directory for the container instance.
* Added the `workDir` method to retrieve the working directory, checking the static `WORKDIR` first before falling back to the instance-specific `workDir`.
* Modified the `start` method to include the working directory in the container definition. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R574) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R608)

### Tests for `GenericContainer` class:

* Fixed a typo in the method name `testStartWIthLabels` to `testStartWithLabels`.
* Added a new test `testStartWithWorkingDirectory` to verify that the working directory is correctly set and used by the container.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced functionality to set and retrieve the working directory for the `GenericContainer` class.
- Added a protected static property `WORKDIR` and a private property `workDir` to manage working directories.
- Implemented the `withWorkingDirectory` method to set the working directory for container instances.
- Added the `workDir` method to retrieve the working directory, prioritizing the static `WORKDIR`.
- Modified the `start` method to incorporate the working directory into the container definition.
- Fixed a typo in the test method name `testStartWIthLabels` to `testStartWithLabels`.
- Added a new test `testStartWithWorkingDirectory` to verify the correct setting and usage of the working directory.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GenericContainer.php</strong><dd><code>Add support for setting and retrieving working directory</code>&nbsp; </dd></summary>
<hr>

src/Containers/GenericContainer.php

<li>Added a protected static property <code>WORKDIR</code> and a private property <br><code>workDir</code>.<br> <li> Implemented <code>withWorkingDirectory</code> method to set the working directory.<br> <li> Added <code>workDir</code> method to retrieve the working directory.<br> <li> Modified <code>start</code> method to include the working directory in the <br>container definition.<br>


</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/15/files#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1">+30/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GenericContainerTest.php</strong><dd><code>Add tests for working directory functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/Containers/GenericContainerTest.php

<li>Fixed a typo in the method name <code>testStartWIthLabels</code>.<br> <li> Added a new test <code>testStartWithWorkingDirectory</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/15/files#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information