### PR TITLE
Refactor and enhance container test strategies and configurations


### DIFF
--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -35,12 +35,9 @@ class GenericContainerTest extends TestCase
     public function testStartWithCommands()
     {
         $container = (new GenericContainer('alpine:latest'))
-            ->withCommands(['echo', 'Hello, World!']);
+            ->withCommands(['echo', 'Hello, World!'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
-
-        while ($instance->isRunning()) {
-            usleep(100);
-        }
 
         $this->assertSame("Hello, World!\n", $instance->getOutput());
     }
@@ -49,12 +46,9 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withEnv('KEY', 'VALUE')
-            ->withCommands(['printenv', 'KEY']);
+            ->withCommands(['printenv', 'KEY'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
-
-        while ($instance->isRunning()) {
-            usleep(100);
-        }
 
         $this->assertSame("VALUE\n", $instance->getOutput());
     }
@@ -63,12 +57,9 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withEnvs(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
-            ->withCommands(['printenv', 'KEY2']);
+            ->withCommands(['printenv', 'KEY2'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
-
-        while ($instance->isRunning()) {
-            usleep(100);
-        }
 
         $this->assertSame("VALUE2\n", $instance->getOutput());
     }
@@ -77,12 +68,9 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
-            ->withCommands(['echo', 'Hello, World!']);
+            ->withCommands(['echo', 'Hello, World!'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
-
-        while ($instance->isRunning()) {
-            usleep(100);
-        }
 
         $this->assertSame("Hello, World!\n", $instance->getOutput());
     }
@@ -120,7 +108,8 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withWorkingDirectory('/tmp')
-            ->withCommands(['pwd']);
+            ->withCommands(['pwd'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
 
         while ($instance->isRunning()) {

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -25,10 +25,6 @@ class GenericContainerTest extends TestCase
             ->withCommand('pwd');
         $instance = $container->start();
 
-        while ($instance->isRunning()) {
-            usleep(100);
-        }
-
         $this->assertSame("/\n", $instance->getOutput());
     }
 
@@ -77,7 +73,7 @@ class GenericContainerTest extends TestCase
 
     public function testStartWithExposedPorts()
     {
-        $container = (new GenericContainer('nginx:latest'))
+        $container = (new GenericContainer('alpine:latest'))
             ->withExposedPorts(80)
             ->withPortStrategy(new LocalRandomPortStrategy());
         $instance = $container->start();
@@ -90,7 +86,7 @@ class GenericContainerTest extends TestCase
 
     public function testStartWithExposedPortsMultiple()
     {
-        $container = (new GenericContainer('nginx:latest'))
+        $container = (new GenericContainer('alpine:latest'))
             ->withExposedPorts([80, 443])
             ->withPortStrategy(new LocalRandomPortStrategy());
         $instance = $container->start();
@@ -122,8 +118,7 @@ class GenericContainerTest extends TestCase
     public function testStartWithPrivilegedMode()
     {
         $container = (new GenericContainer('alpine:latest'))
-            ->withPrivilegedMode(true)
-            ->withCommands(['tail', '-f', '/dev/null']);
+            ->withPrivilegedMode(true);
         $instance = $container->start();
 
         $this->assertSame(true, $instance->getPrivilegedMode());

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -64,11 +64,12 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
-            ->withCommands(['echo', 'Hello, World!'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
 
-        $this->assertSame("Hello, World!\n", $instance->getOutput());
+        $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
+        $this->assertSame("VALUE2", $instance->getLabel('KEY2'));
+        $this->assertSame(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'], $instance->getLabels());
     }
 
     public function testStartWithExposedPorts()
@@ -107,10 +108,6 @@ class GenericContainerTest extends TestCase
             ->withCommands(['pwd'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
         $instance = $container->start();
-
-        while ($instance->isRunning()) {
-            usleep(100);
-        }
 
         $this->assertSame("/tmp\n", $instance->getOutput());
     }


### PR DESCRIPTION
### **User description**
This pull request includes updates to the `GenericContainerTest` unit tests to improve the handling of container start strategies and streamline the test cases. The most important changes include the addition of a `LogMessageWaitStrategy` for various test cases, the removal of unnecessary loops checking for container running status, and some minor adjustments to container configurations.

Test case improvements:

* Added `LogMessageWaitStrategy` to `withCommands` in multiple test cases to improve container startup handling. (`tests/Unit/Containers/GenericContainerTest.php`, [[1]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[2]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[3]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[4]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[5]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76)
* Removed unnecessary loops checking for container running status in multiple test cases, simplifying the test logic. (`tests/Unit/Containers/GenericContainerTest.php`, [[1]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[2]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[3]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[4]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76) [[5]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L28-R76)

Configuration adjustments:

* Changed container image from `nginx:latest` to `alpine:latest` for `testStartWithExposedPorts` and `testStartWithExposedPortsMultiple` to maintain consistency with other tests. (`tests/Unit/Containers/GenericContainerTest.php`, [[1]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L105-R89) [[2]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L123-R108)
* Simplified `testStartWithPrivilegedMode` by removing the command configuration. (`tests/Unit/Containers/GenericContainerTest.php`, [tests/Unit/Containers/GenericContainerTest.phpL136-R121](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L136-R121))


___

### **PR Type**
Tests


___

### **Description**
This pull request refactors the `GenericContainerTest` unit tests to improve efficiency and reliability:
- Introduced `LogMessageWaitStrategy` to ensure containers are fully started before assertions, removing the need for manual polling.
- Removed unnecessary loops that checked for container running status, simplifying the test logic.
- Updated container image from `nginx:latest` to `alpine:latest` for tests involving exposed ports, optimizing for smaller and more efficient images.
- Streamlined test cases by removing redundant command setups, particularly in privileged mode tests.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GenericContainerTest.php</strong><dd><code>Enhance container tests with wait strategy and image update</code></dd></summary>
<hr>

tests/Unit/Containers/GenericContainerTest.php

<li>Added <code>LogMessageWaitStrategy</code> to improve container startup handling.<br> <li> Removed unnecessary loops checking for container running status.<br> <li> Changed container image from <code>nginx:latest</code> to <code>alpine:latest</code>.<br> <li> Streamlined test cases by removing redundant command setups.<br>


</details>


  </td>
  <td><a href="https://github.com/k-kinzal/testcontainers-php/pull/16/files#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5">+13/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information