### PR TITLE
feat(containers): introduce image pull policy for container management

### DIFF
--- a/src/Containers/ContainerInstance.php
+++ b/src/Containers/ContainerInstance.php
@@ -52,6 +52,13 @@ interface ContainerInstance
     public function getMappedPort($exposedPort);
 
     /**
+     * Get the image pull policy of the container.
+     *
+     * @return ImagePullPolicy|null The image pull policy, or null if not set.
+     */
+    public function getImagePullPolicy();
+
+    /**
      * Get the privileged mode status of the container.
      *
      * @return bool True if the container is running in privileged mode, false otherwise.

--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -84,6 +84,18 @@ class GenericContainer implements Container
     private $labels = [];
 
     /**
+     * Define the default image pull policy to be used for the container.
+     * @var ImagePullPolicy|null
+     */
+    protected static $PULL_POLICY;
+
+    /**
+     * The image pull policy to be used for the container.
+     * @var ImagePullPolicy|null
+     */
+    private $pullPolicy;
+
+    /**
      * Define the default working directory to be used for the container.
      * @var string|null
      */
@@ -296,9 +308,11 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withImagePullPolicy($policy)
+    public function withImagePullPolicy($pullPolicy)
     {
-        // TODO: Implement withImagePullPolicy() method.
+        $this->pullPolicy = $pullPolicy;
+
+        return $this;
     }
 
     /**
@@ -438,6 +452,23 @@ class GenericContainer implements Container
     }
 
     /**
+     * Retrieve the image pull policy for the container.
+     *
+     * This method returns the image pull policy that should be used for the container.
+     * If a specific image pull policy is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default image pull policy from the provider.
+     *
+     * @return ImagePullPolicy|null The image pull policy to be used, or null if none is set.
+     */
+    protected function pullPolicy()
+    {
+        if (static::$PULL_POLICY) {
+            return static::$PULL_POLICY;
+        }
+        return $this->pullPolicy;
+    }
+
+    /**
      * Retrieve the working directory for the container.
      *
      * @return string|null
@@ -571,6 +602,7 @@ class GenericContainer implements Container
                 'env' => $this->env(),
                 'label' => $this->labels(),
                 'publish' => $ports,
+                'pull' => $this->pullPolicy(),
                 'workdir' => $this->workDir(),
                 'privileged' => $this->privileged(),
             ]);
@@ -605,6 +637,7 @@ class GenericContainer implements Container
                 $carry[(int)$parts[1]] = (int)$parts[0];
                 return $carry;
             }, []),
+            'pull' => $this->pullPolicy(),
             'workdir' => $this->workDir(),
             'privileged' => $this->privileged(),
         ];

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -26,6 +26,7 @@ class GenericContainerInstance implements ContainerInstance
      *     command?: string,
      *     args?: string[],
      *     ports?: array<int, int>,
+     *     pull?: ImagePullPolicy,
      *     env?: array<string, string>,
      * } The container definition.
      */
@@ -137,6 +138,14 @@ class GenericContainerInstance implements ContainerInstance
             return null;
         }
         return $this->containerDef['ports'][$exposedPort];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImagePullPolicy()
+    {
+        return isset($this->containerDef['pull']) ? $this->containerDef['pull'] : null;
     }
 
     /**

--- a/src/Containers/ImagePullPolicy.php
+++ b/src/Containers/ImagePullPolicy.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Testcontainers\Containers;
+
+/**
+ * Defines the policy for determining when to pull a container image.
+ */
+class ImagePullPolicy
+{
+    /**
+     * The policy to always pull the image.
+     *
+     * @var string
+     */
+    public static $ALWAYS = 'always';
+
+    /**
+     * The policy to use when the image is missing.
+     *
+     * @var string
+     */
+    public static $MISSING = 'missing';
+
+    /**
+     * The policy to never pull the image.
+     *
+     * @var string
+     */
+    public static $NEVER = 'never';
+
+    /**
+     * The pull policy for the container.
+     *
+     * @var string
+     */
+    private $policy;
+
+    /**
+     * @param string $policy
+     */
+    public function __construct($policy)
+    {
+        assert(in_array($policy, [static::$ALWAYS, static::$MISSING, static::$NEVER]));
+
+        $this->policy = $policy;
+    }
+
+    /**
+     * Create a new instance of `PullPolicy` with the `ALWAYS` policy.
+     *
+     * @return self
+     */
+    public static function ALWAYS()
+    {
+        return new self(static::$ALWAYS);
+    }
+
+    /**
+     * Create a new instance of `PullPolicy` with the `MISSING` policy.
+     *
+     * @return self
+     */
+    public static function MISSING()
+    {
+        return new self(static::$MISSING);
+    }
+
+    /**
+     * Create a new instance of `PullPolicy` with the `NEVER` policy.
+     *
+     * @return self
+     */
+    public static function NEVER()
+    {
+        return new self(static::$NEVER);
+    }
+
+    /**
+     * Create a new instance of `PullPolicy` from a string representation.
+     *
+     * @param string $policy The string representation of the pull policy.
+     * @return self
+     * @throws InvalidImagePullPolicyException If the provided policy is not valid.
+     */
+    public static function fromString($policy)
+    {
+        if (!in_array($policy, [static::$ALWAYS, static::$MISSING, static::$NEVER])) {
+            throw new InvalidImagePullPolicyException("Invalid pull policy: $policy");
+        }
+        return new self($policy);
+    }
+
+    /**
+     * Check if the pull policy is set to `ALWAYS`.
+     *
+     * @return bool True if the policy is `ALWAYS`, false otherwise.
+     */
+    public function isAlways()
+    {
+        return $this->policy === static::$ALWAYS;
+    }
+
+    /**
+     * Check if the pull policy is set to `MISSING`.
+     *
+     * @return bool True if the policy is `MISSING`, false otherwise.
+     */
+    public function isMissing()
+    {
+        return $this->policy === static::$MISSING;
+    }
+
+    /**
+     * Check if the pull policy is set to `NEVER`.
+     *
+     * @return bool True if the policy is `NEVER`, false otherwise.
+     */
+    public function isNever()
+    {
+        return $this->policy === static::$NEVER;
+    }
+
+    /**
+     * Get the string representation of the pull policy.
+     *
+     * @return string The string representation of the pull policy.
+     */
+    public function toString()
+    {
+        return $this->policy;
+    }
+
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/src/Containers/InvalidImagePullPolicyException.php
+++ b/src/Containers/InvalidImagePullPolicyException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Testcontainers\Containers;
+
+use Exception;
+
+class InvalidImagePullPolicyException extends Exception
+{
+    public function __construct($policy, $code = 0, $previous = null)
+    {
+        parent::__construct("Invalid image pull policy: $policy", $code, $previous);
+    }
+}

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Containers;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer;
 use Testcontainers\Containers\GenericContainerInstance;
+use Testcontainers\Containers\ImagePullPolicy;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
 
 class GenericContainerInstanceTest extends TestCase
@@ -54,6 +55,16 @@ class GenericContainerInstanceTest extends TestCase
         ]);
 
         $this->assertSame(8080, $instance->getMappedPort(80));
+    }
+
+    public function testGetImagePullPolicy()
+    {
+        $pullPolicy = ImagePullPolicy::ALWAYS();
+        $instance = new GenericContainerInstance('8188d93d8a27', [
+            'pull' => $pullPolicy,
+        ]);
+
+        $this->assertSame($pullPolicy, $instance->getImagePullPolicy());
     }
 
     public function testGetPrivilegedMode()

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Containers;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\GenericContainer;
+use Testcontainers\Containers\ImagePullPolicy;
 use Testcontainers\Containers\PortStrategy\LocalRandomPortStrategy;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
@@ -99,6 +100,15 @@ class GenericContainerTest extends TestCase
         $this->assertTrue(is_int($instance->getMappedPort(443)));
         $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(443));
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
+    }
+
+    public function testStartWithImagePullPolicy()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withImagePullPolicy(ImagePullPolicy::MISSING());
+        $instance = $container->start();
+
+        $this->assertSame(ImagePullPolicy::$MISSING, $instance->getImagePullPolicy()->toString());
     }
 
     public function testStartWithWorkingDirectory()

--- a/tests/Unit/Containers/ImagePullPolicyTest.php
+++ b/tests/Unit/Containers/ImagePullPolicyTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit\Containers;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\ImagePullPolicy;
+use Testcontainers\Containers\InvalidImagePullPolicyException;
+
+class ImagePullPolicyTest extends TestCase
+{
+    public function testImagePullPolicyAlways()
+    {
+        $imagePullPolicy = new ImagePullPolicy(ImagePullPolicy::$ALWAYS);
+
+        $this->assertSame(ImagePullPolicy::$ALWAYS, $imagePullPolicy->toString());
+    }
+
+    public function testImagePullPolicyMissing()
+    {
+        $imagePullPolicy = new ImagePullPolicy(ImagePullPolicy::$MISSING);
+
+        $this->assertSame(ImagePullPolicy::$MISSING, $imagePullPolicy->toString());
+    }
+
+    public function testImagePullPolicyNever()
+    {
+        $imagePullPolicy = new ImagePullPolicy(ImagePullPolicy::$NEVER);
+
+        $this->assertSame(ImagePullPolicy::$NEVER, $imagePullPolicy->toString());
+    }
+
+    public function testAlways()
+    {
+        $imagePullPolicy = ImagePullPolicy::ALWAYS();
+
+        $this->assertSame(ImagePullPolicy::$ALWAYS, $imagePullPolicy->toString());
+    }
+
+    public function testMissing()
+    {
+        $imagePullPolicy = ImagePullPolicy::MISSING();
+
+        $this->assertSame(ImagePullPolicy::$MISSING, $imagePullPolicy->toString());
+    }
+
+    public function testNever()
+    {
+        $imagePullPolicy = ImagePullPolicy::NEVER();
+
+        $this->assertSame(ImagePullPolicy::$NEVER, $imagePullPolicy->toString());
+    }
+
+    public function testFromStringWithAlways()
+    {
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $imagePullPolicy = ImagePullPolicy::fromString(ImagePullPolicy::$ALWAYS);
+
+        $this->assertSame(ImagePullPolicy::$ALWAYS, $imagePullPolicy->toString());
+    }
+
+    public function testFromStringWithMissing()
+    {
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $imagePullPolicy = ImagePullPolicy::fromString(ImagePullPolicy::$MISSING);
+
+        $this->assertSame(ImagePullPolicy::$MISSING, $imagePullPolicy->toString());
+    }
+
+    public function testFromStringWithNever()
+    {
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $imagePullPolicy = ImagePullPolicy::fromString(ImagePullPolicy::$NEVER);
+
+        $this->assertSame(ImagePullPolicy::$NEVER, $imagePullPolicy->toString());
+    }
+
+    public function testFromStringWithInvalidPolicy()
+    {
+        $this->expectException(InvalidImagePullPolicyException::class);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        ImagePullPolicy::fromString('invalid');
+    }
+
+    public function testIsAlways()
+    {
+        $imagePullPolicy = new ImagePullPolicy(ImagePullPolicy::$ALWAYS);
+
+        $this->assertTrue($imagePullPolicy->isAlways());
+    }
+
+    public function testIsMissing()
+    {
+        $imagePullPolicy = new ImagePullPolicy(ImagePullPolicy::$MISSING);
+
+        $this->assertTrue($imagePullPolicy->isMissing());
+    }
+
+    public function testIsNever()
+    {
+        $imagePullPolicy = new ImagePullPolicy(ImagePullPolicy::$NEVER);
+
+        $this->assertTrue($imagePullPolicy->isNever());
+    }
+}

--- a/tests/Unit/Containers/PortStrategy/ConflictBehaviorTest.php
+++ b/tests/Unit/Containers/PortStrategy/ConflictBehaviorTest.php
@@ -52,6 +52,15 @@ class ConflictBehaviorTest extends TestCase
         $this->assertSame(ConflictBehavior::$FAIL, $conflictBehavior->toString());
     }
 
+    public function testFromStringWithInvalidAction()
+    {
+        $this->expectException(InvalidConflictBehaviorException::class);
+        $this->expectExceptionMessage('Invalid conflict behavior: invalid');
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        ConflictBehavior::fromString('invalid');
+    }
+
     public function testIsRetry()
     {
         $conflictBehavior = new ConflictBehavior(ConflictBehavior::$RETRY);
@@ -66,14 +75,5 @@ class ConflictBehaviorTest extends TestCase
 
         $this->assertTrue($conflictBehavior->isFail());
         $this->assertFalse($conflictBehavior->isRetry());
-    }
-
-    public function testFromStringWithInvalidAction()
-    {
-        $this->expectException(InvalidConflictBehaviorException::class);
-        $this->expectExceptionMessage('Invalid conflict behavior: invalid');
-
-        /** @noinspection PhpUnhandledExceptionInspection */
-        ConflictBehavior::fromString('invalid');
     }
 }


### PR DESCRIPTION
Add support for defining and retrieving image pull policies in containers, allowing more control over when container images are pulled. This includes the creation of the `ImagePullPolicy` class with predefined policies (`ALWAYS`, `MISSING`, `NEVER`) and methods to handle these policies. The `GenericContainer` and `GenericContainerInstance` classes are updated to incorporate this feature, providing methods to set and get the image pull policy. Tests are added to ensure the correct functionality of the new feature. This enhancement allows for more flexible and efficient container management by specifying image pull behavior.