### PR TITLE
Add /review command to PR agent configuration

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 [github_app]
 pr_commands = [
     "/describe",
+    "/review",
     "/review auto_approve",
     "/improve",
 ]


### PR DESCRIPTION
This pull request includes a small change to the `.pr_agent.toml` file. The change adds a new command to the list of GitHub app PR commands.

* [`.pr_agent.toml`](diffhunk://#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7R4): Added the `/review` command to the `pr_commands` list.