### PR TITLE
Code cleanup and consistency improvements in Testcontainers library

### DIFF
--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -308,9 +308,9 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withImagePullPolicy($pullPolicy)
+    public function withImagePullPolicy($policy)
     {
-        $this->pullPolicy = $pullPolicy;
+        $this->pullPolicy = $policy;
 
         return $this;
     }
@@ -532,7 +532,7 @@ class GenericContainer implements Container
      * @param ContainerInstance $instance The container instance for which to get the wait strategy.
      * @return WaitStrategy|null The wait strategy to be used, or null if none is set.
      */
-    protected function waitStrategy($instance)
+    protected function waitStrategy(/** @noinspection PhpUnusedParameterInspection */ $instance)
     {
         if (static::$WAIT_STRATEGY !== null) {
             $strategy = $this->waitStrategyProvider->get(static::$WAIT_STRATEGY);

--- a/src/Testcontainers.php
+++ b/src/Testcontainers.php
@@ -5,7 +5,6 @@ namespace Testcontainers;
 use LogicException;
 use Testcontainers\Containers\Container;
 use Testcontainers\Containers\ContainerInstance;
-use Testcontainers\Containers\GenericContainer;
 
 /**
  * Class Testcontainers

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer;
 use Testcontainers\Containers\GenericContainerInstance;
 use Testcontainers\Containers\ImagePullPolicy;
-use Testcontainers\Docker\Exception\NoSuchContainerException;
 
 class GenericContainerInstanceTest extends TestCase
 {

--- a/tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php
+++ b/tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php
@@ -52,7 +52,6 @@ class TestWaitStrategy implements WaitStrategy
 {
     public function waitUntilReady($instance)
     {
-        return;
     }
 
     public function getName()

--- a/tests/Unit/Functions/ArrayFlattenTest.php
+++ b/tests/Unit/Functions/ArrayFlattenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Functions;
+namespace Tests\Unit\Functions;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/TestcontainersTest.php
+++ b/tests/Unit/TestcontainersTest.php
@@ -3,9 +3,6 @@
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Testcontainers\Containers\GenericContainer;
-use Testcontainers\Docker\Exception\DockerException;
-use Testcontainers\Hook\AfterStartHook;
 use Testcontainers\Testcontainers;
 use Tests\Images\AlpineContainer;
 


### PR DESCRIPTION
This pull request includes several changes to the `Testcontainers` library, focusing on code cleanup, improving consistency, and updating namespaces. The most important changes are summarized below:

Code cleanup and consistency:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L311-R313): Renamed the parameter in `withImagePullPolicy` from `$pullPolicy` to `$policy` for consistency.
* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L535-R535): Added a `PhpUnusedParameterInspection` annotation to the `waitStrategy` method to suppress warnings for unused parameters.

Namespace updates:

* [`tests/Unit/Functions/ArrayFlattenTest.php`](diffhunk://#diff-bfeb4d55bcd00166a115569f53611cba52c494e4ce0b06bddbdd851656f625daL3-R3): Updated the namespace from `Tests\Functions` to `Tests\Unit\Functions`.

Unused imports removal:

* [`src/Testcontainers.php`](diffhunk://#diff-be13d3cec39e49a239045ba0467fafe230684c677e38cb820bc947880a583facL8): Removed the unused import of `GenericContainer`.
* [`tests/Unit/Containers/GenericContainerInstanceTest.php`](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L9): Removed the unused import of `NoSuchContainerException`.
* [`tests/Unit/TestcontainersTest.php`](diffhunk://#diff-9ed780ea381c09c73b47cf72dd87ce9c18eeb622fea72492f8b5cc05b2b4451bL6-L8): Removed unused imports of `GenericContainer`, `DockerException`, and `AfterStartHook`.