### PR TITLE
feat(GenericContainer): add support for volumesFrom to manage contain…

### DIFF
--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -55,6 +55,7 @@ class GenericContainerInstance implements ContainerInstance
      *   command?: string,
      *   args?: string[],
      *   mounts?: string[],
+     *   volumesFrom?: string[],
      *   ports?: array<int, int>,
      *   pull?: ImagePullPolicy,
      *   env?: array<string, string>,


### PR DESCRIPTION
This pull request introduces several changes to the `GenericContainer` class and related files to support volume management in containers. The most important changes include adding new properties and methods for handling volumes, updating the `start` method to use these volumes, and adding corresponding tests.

### Volume Management Enhancements:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R67-R81): Added new properties `static $VOLUMES_FROM` and `private $volumesFrom` to define and manage container volumes.
* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L221-R241): Implemented the `withVolumesFrom` method to add volumes to the container configuration.
* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R528-R570): Added the `volumesFrom` method to retrieve and validate volumes for the container.
* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R782-R793): Updated the `start` method to include volumes in the container configuration. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R782-R793) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R811) [[3]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R844)

### Test Enhancements:

* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R40-R59): Added a new test `testWithVolumesFrom` to verify the functionality of volumes in containers.

### Minor Improvements:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L494-R517): Updated the `mounts` method to improve error messages by removing unnecessary mount details.