### PR TITLE
Add extra hosts configuration support for containers

### DIFF
--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -54,6 +54,7 @@ class GenericContainerInstance implements ContainerInstance
      *   image?: string,
      *   command?: string,
      *   args?: string[],
+     *   hosts?: string[],
      *   mounts?: string[],
      *   volumesFrom?: string[],
      *   ports?: array<int, int>,

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -76,6 +76,16 @@ class GenericContainerTest extends TestCase
         $this->assertSame("Hello, World!\n", $instance->getOutput());
     }
 
+    public function testStartWithExtraHost()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withExtraHost('example.com', '127.0.0.1')
+            ->withCommands(['sh', '-c', 'ping -c 1 example.com']);
+        $instance = $container->start();
+
+        $this->assertStringStartsWith('PING example.com (127.0.0.1)', $instance->getOutput());
+    }
+
     public function testStartWithEnv()
     {
         $container = (new GenericContainer('alpine:latest'))


### PR DESCRIPTION
This pull request introduces new functionality to handle extra hosts in the `GenericContainer` class. The changes include adding properties and methods to manage extra hosts, modifying the `start` method to incorporate these hosts, and updating tests to verify the new functionality.

### Enhancements to `GenericContainer`:

* Added `protected static $EXTRA_HOSTS` and `private $extraHosts` properties to store extra hosts.
* Implemented the `withExtraHost` method to add extra hosts to the container.
* Added the `extraHost` method to retrieve extra hosts.

### Modifications to `start` method:

* Updated the `start` method to include extra hosts in the Docker client run configuration. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R809-R816) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R857) [[3]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R892)

### Test updates:

* Added a new test `testStartWithExtraHost` to verify that the container can start with extra hosts.