### PR TITLE
Add network mode configuration support for containers

### DIFF
--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -67,6 +67,18 @@ class GenericContainer implements Container
     private $extraHosts = [];
 
     /**
+     * Define the default network mode to be used for the container.
+     * @var string|null
+     */
+    protected static $NETWORK_MODE;
+
+    /**
+     * The network mode to be used for the container.
+     * @var string|null
+     */
+    private $networkMode;
+
+    /**
      * Define the default mounts to be used for the container.
      * @var string[]|null
      */
@@ -361,7 +373,9 @@ class GenericContainer implements Container
      */
     public function withNetworkMode($networkMode)
     {
-        // TODO: Implement withNetworkMode() method.
+        $this->networkMode = $networkMode;
+
+        return $this;
     }
 
     /**
@@ -475,6 +489,22 @@ class GenericContainer implements Container
             return $this->extraHosts;
         }
         return [];
+    }
+
+    /**
+     * Retrieve the network mode to be used for the container.
+     *
+     * @return string|null
+     */
+    protected function networkMode()
+    {
+        if (static::$NETWORK_MODE) {
+            return static::$NETWORK_MODE;
+        }
+        if ($this->networkMode) {
+            return $this->networkMode;
+        }
+        return null;
     }
 
     /**
@@ -859,6 +889,7 @@ class GenericContainer implements Container
                 'env' => $this->env(),
                 'label' => $this->labels(),
                 'mount' => $mounts,
+                'network' => $this->networkMode(),
                 'volumesFrom' => $volumesFrom,
                 'publish' => $ports,
                 'pull' => $this->pullPolicy(),
@@ -893,6 +924,7 @@ class GenericContainer implements Container
             'env' => $this->env(),
             'labels' => $this->labels(),
             'mounts' => $mounts,
+            'networkMode' => $this->networkMode(),
             'volumesFrom' => $volumesFrom,
             'ports' => array_reduce($ports, function ($carry, $item) {
                 $parts = explode(':', $item);

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -56,6 +56,7 @@ class GenericContainerInstance implements ContainerInstance
      *   args?: string[],
      *   hosts?: string[],
      *   mounts?: string[],
+     *   network?: string,
      *   volumesFrom?: string[],
      *   ports?: array<int, int>,
      *   pull?: ImagePullPolicy,

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -86,6 +86,16 @@ class GenericContainerTest extends TestCase
         $this->assertStringStartsWith('PING example.com (127.0.0.1)', $instance->getOutput());
     }
 
+    public function testStartWithNetworkMode()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withNetworkMode('none')
+            ->withCommands(['sh', '-c', 'ls /sys/class/net']);
+        $instance = $container->start();
+
+        $this->assertNotContains('eth0', $instance->getOutput());
+    }
+
     public function testStartWithEnv()
     {
         $container = (new GenericContainer('alpine:latest'))

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -93,7 +93,7 @@ class GenericContainerTest extends TestCase
             ->withCommands(['sh', '-c', 'ls /sys/class/net']);
         $instance = $container->start();
 
-        $this->assertNotContains('eth0', $instance->getOutput());
+        $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
     }
 
     public function testStartWithEnv()


### PR DESCRIPTION
This pull request introduces the concept of network modes to the `GenericContainer` class in the `src/Containers/GenericContainer.php` file. The changes involve adding new properties and methods to handle network modes, updating the `start` method to include network mode in the container configuration, and adding a test case to verify the new functionality.

Key changes include:

### Enhancements to `GenericContainer` class:

* Added `protected static $NETWORK_MODE` and `private $networkMode` properties to define and store the network mode for the container.
* Implemented the `withNetworkMode` method to set the network mode for the container.
* Added the `networkMode` method to retrieve the network mode, checking both the static and instance properties.

### Updates to the `start` method:

* Modified the `start` method to include the network mode in the container configuration. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R892) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R927)

### Test case addition:

* Added a new test case `testStartWithNetworkMode` to ensure that the network mode is correctly applied and that the container starts with the specified network settings.