### PR TITLE
feat(tests): introduce Docker in Docker (DinD) container for testing

### DIFF
--- a/src/Containers/WaitStrategy/HttpProbeGetHeaders.php
+++ b/src/Containers/WaitStrategy/HttpProbeGetHeaders.php
@@ -10,6 +10,9 @@ class HttpProbeGetHeaders implements HttpProbe
         if ($headers === false) {
             return false;
         }
+        if (!isset($headers[0])) {
+            return false;
+        }
         $statusCode = (int) substr($headers[0], 9, 3);
         return $statusCode == $responseCode;
     }

--- a/tests/Images/DinD.php
+++ b/tests/Images/DinD.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Images;
+
+use Testcontainers\Containers\GenericContainer;
+use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
+
+/**
+ * Docker in Docker container
+ */
+class DinD extends GenericContainer
+{
+    /**
+     * The Docker image to be used for the DinD container.
+     *
+     * @var string
+     */
+    protected static $IMAGE = 'docker:27.4.1-dind';
+
+    /**
+     * The commands to be executed in the DinD container.
+     *
+     * Note: The `--tls=false` option is included to prevent slow performance.
+     *
+     * @var string[]
+     */
+    protected static $COMMANDS = [
+        'dockerd-entrypoint.sh',
+        '--tls=false'
+    ];
+
+    /**
+     * The environment variables to be set in the DinD container.
+     *
+     * Note: TLS is disabled for performance and ease of use.
+     *
+     * @var array
+     */
+    protected static $ENVIRONMENTS = [
+        'DOCKER_TLS_CERTDIR' => ''
+    ];
+
+    /**
+     * The ports to be exposed by the DinD container.
+     *
+     * @var int[]
+     */
+    protected static $PORTS = [2375];
+
+    /**
+     * The port strategy to be used for the DinD container.
+     * Port 2375 is used when TLS is disabled, and port 2376 is used when TLS is enabled.
+     *
+     * @var string
+     */
+    protected static $PORT_STRATEGY = 'local_random';
+
+    /**
+     * Whether the DinD container should run in privileged mode.
+     *
+     * @var bool
+     */
+    protected static $PRIVILEGED = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function waitStrategy($instance)
+    {
+        return (new HttpWaitStrategy())
+            ->withSchema('http')
+            ->withPath('/_ping');
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Docker in Docker (DinD) container for testing purposes and updates the unit tests to utilize this new container. The most important changes include adding the DinD container class, integrating the DinD container into existing tests, and modifying the test methods to use the new container.

### Addition of DinD Container:

* [`tests/Images/DinD.php`](diffhunk://#diff-15108f476d6f2c3799ed7b171f7d5244a1f545b164b3defa71777b8cc025f6d9R1-R74): Added a new class `DinD` that extends `GenericContainer` to define a Docker in Docker container with specific configurations for testing purposes.

### Integration into Unit Tests:

* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fR15-R16): Imported the new `DinD` class and `Testcontainers` utility.

### Modifications to Test Methods:

* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fR97-R120): Updated `testRunWithPortConflict()` to run the `DinD` container and configure the `DockerClient` to use the DinD container's host and mapped port.
* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fR160-L176): Updated `testStop()` to run the `DinD` container and configure the `DockerClient` to use the DinD container's host and mapped port.
* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fR160-L176): Updated `testLogs()` to run the `DinD` container and configure the `DockerClient` to use the DinD container's host and mapped port.
* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fL191-L193): Updated `testFollowLogs()` to run the `DinD` container and configure the `DockerClient` to use the DinD container's host and mapped port.