### PR TITLE
Add Docker network creation functionality with output handling

### DIFF
--- a/src/Docker/DockerClient.php
+++ b/src/Docker/DockerClient.php
@@ -274,12 +274,12 @@ class DockerClient
         }
 
         $commandline = array_filter(array_flatten([
-        $this->command,
-        $this->arrayToArgs($this->options),
-        'stop',
-        $this->arrayToArgs($options),
-        $containerIds,
-    ]));
+            $this->command,
+            $this->arrayToArgs($this->options),
+            'stop',
+            $this->arrayToArgs($options),
+            $containerIds,
+        ]));
         $process = new Process(
             $commandline,
             $this->cwd,
@@ -425,6 +425,42 @@ class DockerClient
         $process->start();
 
         return new DockerFollowLogsOutput($process);
+    }
+
+    /**
+     * Create a new Docker network.
+     *
+     * This method wraps the `docker network create` command to create a new Docker network.
+     *
+     * @param string $network The name of the Docker network to create.
+     * @param array $options Additional options for the Docker network create command.
+     * @return DockerNetworkCreateOutput The output of the Docker network create command.
+     */
+    public function networkCreate($network, $options = [])
+    {
+        $commandline = array_filter(array_flatten([
+            $this->command,
+            $this->arrayToArgs($this->options),
+            'network',
+            'create',
+            $this->arrayToArgs($options),
+            $network,
+        ]));
+        $process = new Process(
+            $commandline,
+            $this->cwd,
+            $this->env,
+            $this->input,
+            $this->timeout,
+            $this->proc_options
+        );
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new DockerException($process);
+        }
+
+        return new DockerNetworkCreateOutput($process);
     }
 
     /**

--- a/src/Docker/DockerNetworkCreateOutput.php
+++ b/src/Docker/DockerNetworkCreateOutput.php
@@ -4,5 +4,4 @@ namespace Testcontainers\Docker;
 
 class DockerNetworkCreateOutput extends DockerOutput
 {
-
 }

--- a/src/Docker/DockerNetworkCreateOutput.php
+++ b/src/Docker/DockerNetworkCreateOutput.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Testcontainers\Docker;
+
+class DockerNetworkCreateOutput extends DockerOutput
+{
+
+}

--- a/tests/Unit/Docker/DockerClientTest.php
+++ b/tests/Unit/Docker/DockerClientTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\DockerFollowLogsOutput;
 use Testcontainers\Docker\DockerLogsOutput;
+use Testcontainers\Docker\DockerNetworkCreateOutput;
 use Testcontainers\Docker\DockerProcessStatusOutput;
 use Testcontainers\Docker\DockerRunOutput;
 use Testcontainers\Docker\DockerRunWithDetachOutput;
@@ -201,5 +202,20 @@ class DockerClientTest extends TestCase
         $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[0]) === 1);
         $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[1]) === 1);
         $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[2]) === 1);
+    }
+
+    public function testNetworkCreate()
+    {
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = new DockerClient();
+        $client->withGlobalOptions([
+            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
+        ]);
+        $output = $client->networkCreate('test-network');
+
+        $this->assertInstanceOf(DockerNetworkCreateOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertTrue(preg_match('/^[0-9a-f]{64}/', $output->getOutput()) === 1);
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to the Docker client, specifically adding functionality to create Docker networks. The changes include updates to the Docker client class, the creation of a new output class, and the addition of a corresponding unit test.

### New Feature: Docker Network Creation

* [`src/Docker/DockerClient.php`](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R430-R465): Added the `networkCreate` method which wraps the `docker network create` command to create a new Docker network.
* [`src/Docker/DockerNetworkCreateOutput.php`](diffhunk://#diff-524ac3d1d5b3c4d407de20090b896c0d309fdda0cebb4402f3b1aa910a756c73R1-R8): Created a new class `DockerNetworkCreateOutput` that extends `DockerOutput` to handle the output of the Docker network creation process.

### Unit Tests

* `tests/Unit/Docker/DockerClientTest.php`: 
  * Imported the new `DockerNetworkCreateOutput` class.
  * Added the `testNetworkCreate` method to test the new `networkCreate` method in `DockerClient`.