### PR TITLE
Add support for network aliases and custom Docker client configuration

### DIFF
--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -3,6 +3,7 @@
 namespace Testcontainers\Containers;
 
 use LogicException;
+use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\DockerClientFactory;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
 
@@ -11,6 +12,13 @@ use Testcontainers\Docker\Exception\NoSuchContainerException;
  */
 class GenericContainerInstance implements ContainerInstance
 {
+    /**
+     * The docker client.
+     *
+     * @var DockerClient|null The docker client.
+     */
+    private $client;
+
     /**
      * The unique identifier for the container.
      *
@@ -57,6 +65,7 @@ class GenericContainerInstance implements ContainerInstance
      *   hosts?: string[],
      *   mounts?: string[],
      *   network?: string,
+     *   networkAliases?: string[],
      *   volumesFrom?: string[],
      *   ports?: array<int, int>,
      *   pull?: ImagePullPolicy,
@@ -72,6 +81,17 @@ class GenericContainerInstance implements ContainerInstance
     public function __destruct()
     {
         $this->stop();
+    }
+
+    /**
+     * Sets the docker client.
+     *
+     * @param DockerClient $client
+     * @return void
+     */
+    public function setDockerClient($client)
+    {
+        $this->client = $client;
     }
 
     /**
@@ -174,8 +194,8 @@ class GenericContainerInstance implements ContainerInstance
      */
     public function getOutput()
     {
-        $client = DockerClientFactory::create();
-        $output = $client->logs($this->containerId);
+        $client = $this->client ? $this->client : DockerClientFactory::create();
+        $output = $this->client->logs($this->containerId);
         return $output->getOutput();
     }
 
@@ -184,7 +204,7 @@ class GenericContainerInstance implements ContainerInstance
      */
     public function getErrorOutput()
     {
-        $client = DockerClientFactory::create();
+        $client = $this->client ? $this->client : DockerClientFactory::create();
         $output = $client->logs($this->containerId);
         return $output->getErrorOutput();
     }
@@ -219,7 +239,7 @@ class GenericContainerInstance implements ContainerInstance
         if ($this->running === false) {
             return false;
         }
-        $client = DockerClientFactory::create();
+        $client = $this->client ? $this->client : DockerClientFactory::create();
         $output = $client->processStatus([
             'filter' => "id=$this->containerId",
         ]);
@@ -240,7 +260,7 @@ class GenericContainerInstance implements ContainerInstance
     public function stop()
     {
         try {
-            $client = DockerClientFactory::create();
+            $client = $this->client ? $this->client : DockerClientFactory::create();
             $client->stop($this->containerId);
         } catch (NoSuchContainerException $e) {
             // Do nothing

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -195,7 +195,7 @@ class GenericContainerInstance implements ContainerInstance
     public function getOutput()
     {
         $client = $this->client ? $this->client : DockerClientFactory::create();
-        $output = $this->client->logs($this->containerId);
+        $output = $client->logs($this->containerId);
         return $output->getOutput();
     }
 

--- a/src/Docker/DockerClientFactory.php
+++ b/src/Docker/DockerClientFactory.php
@@ -17,9 +17,9 @@ class DockerClientFactory
      * This static property holds the Docker client instance. It is initialized
      * when the `create` method is called for the first time.
      *
-     * @var DockerClient|null
+     * @var array<string, DockerClient>
      */
-    private static $client;
+    private static $client = [];
 
     /**
      * The configuration options for the Docker client.
@@ -52,36 +52,40 @@ class DockerClientFactory
      * It returns a clone of the Docker client to ensure that each call to this method
      * provides a fresh instance.
      *
+     * @param array $config The configuration options for the Docker client.
      * @return DockerClient A new instance of DockerClient.
      */
-    public static function create()
+    public static function create($config = [])
     {
-        if (self::$client === null) {
+        $config = array_merge(self::$config, $config);
+        $hash = md5(serialize($config));
+
+        if (!isset(self::$client[$hash])) {
             $client = new DockerClient();
-            if (isset(self::$config['command'])) {
-                $client = $client->withCommand(self::$config['command']);
+            if (isset($config['command'])) {
+                $client = $client->withCommand($config['command']);
             }
-            if (isset(self::$config['globalOptions'])) {
-                $client = $client->withGlobalOptions(self::$config['globalOptions']);
+            if (isset($config['globalOptions'])) {
+                $client = $client->withGlobalOptions($config['globalOptions']);
             }
-            if (isset(self::$config['cwd'])) {
-                $client = $client->withCwd(self::$config['cwd']);
+            if (isset($config['cwd'])) {
+                $client = $client->withCwd($config['cwd']);
             }
-            if (isset(self::$config['env'])) {
-                $client = $client->withEnv(self::$config['env']);
+            if (isset($config['env'])) {
+                $client = $client->withEnv($config['env']);
             }
-            if (isset(self::$config['input'])) {
-                $client = $client->withInput(self::$config['input']);
+            if (isset($config['input'])) {
+                $client = $client->withInput($config['input']);
             }
-            if (isset(self::$config['timeout'])) {
-                $client = $client->withTimeout(self::$config['timeout']);
+            if (isset($config['timeout'])) {
+                $client = $client->withTimeout($config['timeout']);
             }
-            if (isset(self::$config['procOptions'])) {
-                $client = $client->withProcOptions(self::$config['procOptions']);
+            if (isset($config['procOptions'])) {
+                $client = $client->withProcOptions($config['procOptions']);
             }
-            self::$client = $client;
+            self::$client[$hash] = $client;
         }
 
-        return clone self::$client;
+        return clone self::$client[$hash];
     }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `GenericContainer` and `GenericContainerInstance` classes by adding support for Docker clients and network aliases. Additionally, it modifies the `DockerClientFactory` to handle multiple configurations and updates the unit tests to cover the new functionality.

### Enhancements to Docker client handling:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R17): Introduced a private `$client` property and a `withDockerClient` method to set the Docker client. Updated the `start` method to use the provided Docker client if available. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R17) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R28-R33) [[3]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R265-R276) [[4]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L884-R933)
* [`src/Containers/GenericContainerInstance.php`](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cR6): Added a private `$client` property and a `setDockerClient` method. Updated methods like `getOutput`, `getErrorOutput`, `isRunning`, and `stop` to use the provided Docker client if available. [[1]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cR6) [[2]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cR15-R21) [[3]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cR86-R96) [[4]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL177-R198) [[5]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL187-R207) [[6]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL222-R242) [[7]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL243-R263)

### Support for network aliases:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R88-R99): Added properties and methods to manage network aliases, including `protected static $NETWORK_ALIASES`, `private $networkAliases`, `withNetworkAliases`, and `networkAliases`. Updated the `start` method to include network aliases in the container definition. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R88-R99) [[2]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L386-R419) [[3]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R543-R558) [[4]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R942) [[5]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R978)

### Enhancements to Docker client factory:

* [`src/Docker/DockerClientFactory.php`](diffhunk://#diff-0d2137f8c89f8fd479c16dec7b32209286fd79f13f1018ac3cac0d922a68c6cbL20-R22): Modified the `create` method to handle multiple configurations by using an array to store Docker clients based on a hash of their configuration. [[1]](diffhunk://#diff-0d2137f8c89f8fd479c16dec7b32209286fd79f13f1018ac3cac0d922a68c6cbL20-R22) [[2]](diffhunk://#diff-0d2137f8c89f8fd479c16dec7b32209286fd79f13f1018ac3cac0d922a68c6cbR55-R89)

### Updates to unit tests:

* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R12-R14): Added a new test `testStartWithNetworkAliases` to verify the functionality of starting a container with network aliases. [[1]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R12-R14) [[2]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R102-R123)