### PR TITLE
Implement container startup timeout functionality with configurable duration

### DIFF
--- a/src/Containers/Container.php
+++ b/src/Containers/Container.php
@@ -140,7 +140,7 @@ interface Container
     /**
      * Set the duration of waiting time until the container is treated as started.
      *
-     * @param Duration $timeout The duration to wait.
+     * @param int $timeout The duration to wait.
      * @return self
      */
     public function withStartupTimeout($timeout);

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Testcontainers\Containers\BindMode;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\GenericContainer;
@@ -202,6 +203,16 @@ class GenericContainerTest extends TestCase
         $instance = $container->start();
 
         $this->assertSame("/tmp\n", $instance->getOutput());
+    }
+
+    public function testStartWithStartupTimeout()
+    {
+        $this->expectException(ProcessTimedOutException::class);
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withStartupTimeout(1)
+            ->withCommands(['sleep', '5']);
+        $instance = $container->start();
     }
 
     public function testStartWithPrivilegedMode()


### PR DESCRIPTION
This pull request includes several changes to the `GenericContainer` class and related tests to introduce and handle a startup timeout for containers. The most important changes include modifying the `withStartupTimeout` method, adding a `startupTimeout` property, and updating the `start` method to use the timeout. Additionally, a new test has been added to verify the startup timeout functionality.

### Changes to `GenericContainer` class:

* Added `protected static $STARTUP_TIMEOUT` and `private $startupTimeout` properties to define and store the startup timeout for the container.
* Implemented the `withStartupTimeout` method to set the `startupTimeout` property and return the instance.
* Added the `startupTimeout` method to retrieve the startup timeout, checking both the static and instance properties.
* Updated the `start` method to use the `startupTimeout` if it is set, by calling `withTimeout` on the client.

### Changes to tests:

* Imported `ProcessTimedOutException` in `GenericContainerTest.php` to handle timeout exceptions.
* Added a new test `testStartWithStartupTimeout` to verify that the container startup times out as expected.