### PR TITLE
Remove unused withCopyToContainer method from Container interface and implementation

### DIFF
--- a/src/Containers/Container.php
+++ b/src/Containers/Container.php
@@ -38,15 +38,6 @@ interface Container
     public function withExposedPorts($ports);
 
     /**
-     * Set the content to be copied to the container before it starts.
-     *
-     * @param Transferable $transferable The content to be copied.
-     * @param string $containerPath The destination path inside the container.
-     * @return self
-     */
-    public function withCopyToContainer($transferable, $containerPath);
-
-    /**
      * Add an environment variable to the container.
      *
      * @param string $key The name of the environment variable.

--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -333,14 +333,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withCopyToContainer($transferable, $containerPath)
-    {
-        // TODO: Implement withCopyToContainer() method.
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withEnv($key, $value)
     {
         $this->env[$key] = $value;


### PR DESCRIPTION
`withCopyToContainer` is a function for reusing containers. It has been removed because there are no plans to implement reuse at this time.

# details

This pull request involves the removal of an unused method from the `Container` interface and its implementation in the `GenericContainer` class. The changes streamline the code by eliminating the `withCopyToContainer` method, which was not implemented.

Codebase simplification:

* [`src/Containers/Container.php`](diffhunk://#diff-fe8e987d1aa50c89af16fb40b1cc77c18c045294a9d49d5c5f63e9f3b27e8422L40-L48): Removed the `withCopyToContainer` method from the interface.
* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L333-L340): Removed the unimplemented `withCopyToContainer` method.