### PR TITLE
Refactor code for clarity and maintainability, enhance tests

### DIFF
--- a/src/Containers/GenericContainer.php
+++ b/src/Containers/GenericContainer.php
@@ -1000,7 +1000,7 @@ class GenericContainer implements Container
             }
         }
 
-        $client = $this->client ? $this->client : DockerClientFactory::create();
+        $client = $this->client ?: DockerClientFactory::create();
 
         try {
             $options = [

--- a/src/Containers/GenericContainerInstance.php
+++ b/src/Containers/GenericContainerInstance.php
@@ -194,7 +194,7 @@ class GenericContainerInstance implements ContainerInstance
      */
     public function getOutput()
     {
-        $client = $this->client ? $this->client : DockerClientFactory::create();
+        $client = $this->client ?: DockerClientFactory::create();
         $output = $client->logs($this->containerId);
         return $output->getOutput();
     }
@@ -204,7 +204,7 @@ class GenericContainerInstance implements ContainerInstance
      */
     public function getErrorOutput()
     {
-        $client = $this->client ? $this->client : DockerClientFactory::create();
+        $client = $this->client ?: DockerClientFactory::create();
         $output = $client->logs($this->containerId);
         return $output->getErrorOutput();
     }
@@ -239,7 +239,7 @@ class GenericContainerInstance implements ContainerInstance
         if ($this->running === false) {
             return false;
         }
-        $client = $this->client ? $this->client : DockerClientFactory::create();
+        $client = $this->client ?: DockerClientFactory::create();
         $output = $client->processStatus([
             'filter' => "id=$this->containerId",
         ]);
@@ -260,7 +260,7 @@ class GenericContainerInstance implements ContainerInstance
     public function stop()
     {
         try {
-            $client = $this->client ? $this->client : DockerClientFactory::create();
+            $client = $this->client ?: DockerClientFactory::create();
             $client->stop($this->containerId);
         } catch (NoSuchContainerException $e) {
             // Do nothing

--- a/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
@@ -22,7 +22,7 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
      */
     public function waitUntilStartupSuccessful($containerId)
     {
-        $client = $this->client ? $this->client : DockerClientFactory::create();
+        $client = $this->client ?: DockerClientFactory::create();
         try {
             while (true) {
                 $output = $client->inspect($containerId);

--- a/src/Docker/Types/State.php
+++ b/src/Docker/Types/State.php
@@ -2,8 +2,6 @@
 
 namespace Testcontainers\Docker\Types;
 
-use DateTime;
-use Exception;
 use LogicException;
 use Testcontainers\Docker\Exception\InvalidValueException;
 

--- a/src/Exceptions/InvalidFormatException.php
+++ b/src/Exceptions/InvalidFormatException.php
@@ -22,7 +22,6 @@ class InvalidFormatException extends Exception
     public function __construct($actual, $expects = [], $code = 0, $previous = null)
     {
         if (empty($expects)) {
-            $message = "Invalid format: $actual";
             parent::__construct("Invalid format: $actual", $code, $previous);
         } else {
             $expects = implode(', ', $expects);

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -79,6 +79,7 @@ class GenericContainerInstanceTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withCommands(['echo', 'Hello, World!']);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         while ($instance->isRunning()) {
@@ -92,6 +93,7 @@ class GenericContainerInstanceTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withCommands(['ls', '/not-exist-dir']);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         while ($instance->isRunning()) {

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -19,6 +19,7 @@ class GenericContainerTest extends TestCase
     public function testStart()
     {
         $container = new GenericContainer('alpine:latest');
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertInstanceOf(ContainerInstance::class, $instance);
@@ -36,6 +37,7 @@ class GenericContainerTest extends TestCase
             ->withFileSystemBind($path, '/tmp/test', BindMode::READ_WRITE())
             ->withCommands(['cat', '/tmp/test'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("Hello, World!", $instance->getOutput());
@@ -50,12 +52,14 @@ class GenericContainerTest extends TestCase
 
         $container = (new GenericContainer('alpine:latest'))
             ->withFileSystemBind($path, '/tmp/test', BindMode::READ_WRITE());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance1 = $container->start();
 
         $container = (new GenericContainer('alpine:latest'))
             ->withVolumesFrom($instance1, BindMode::READ_ONLY())
             ->withCommands(['cat', '/tmp/test'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance2 = $container->start();
 
         $this->assertSame("Hello, World!", $instance2->getOutput());
@@ -65,6 +69,7 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withCommand('pwd');
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("/\n", $instance->getOutput());
@@ -75,6 +80,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withCommands(['echo', 'Hello, World!'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("Hello, World!\n", $instance->getOutput());
@@ -85,6 +91,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withExtraHost('example.com', '127.0.0.1')
             ->withCommands(['sh', '-c', 'ping -c 1 example.com']);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertStringStartsWith('PING example.com (127.0.0.1)', $instance->getOutput());
@@ -95,6 +102,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withNetworkMode('none')
             ->withCommands(['sh', '-c', 'ls /sys/class/net']);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
@@ -117,6 +125,7 @@ class GenericContainerTest extends TestCase
             ->withNetworkMode($network)
             ->withNetworkAliases(['my-alias'])
             ->withCommands(['sh', '-c', 'ping -c 1 my-alias']);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertStringStartsWith('PING my-alias', $instance->getOutput());
@@ -128,6 +137,7 @@ class GenericContainerTest extends TestCase
             ->withEnv('KEY', 'VALUE')
             ->withCommands(['printenv', 'KEY'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("VALUE\n", $instance->getOutput());
@@ -139,6 +149,7 @@ class GenericContainerTest extends TestCase
             ->withEnvs(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
             ->withCommands(['printenv', 'KEY2'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("VALUE2\n", $instance->getOutput());
@@ -149,6 +160,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
@@ -161,6 +173,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withExposedPorts(80)
             ->withPortStrategy(new LocalRandomPortStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertInstanceOf(ContainerInstance::class, $instance);
@@ -174,6 +187,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withExposedPorts([80, 443])
             ->withPortStrategy(new LocalRandomPortStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertInstanceOf(ContainerInstance::class, $instance);
@@ -189,6 +203,7 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withImagePullPolicy(ImagePullPolicy::MISSING());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame(ImagePullPolicy::$MISSING, $instance->getImagePullPolicy()->toString());
@@ -200,6 +215,7 @@ class GenericContainerTest extends TestCase
             ->withWorkingDirectory('/tmp')
             ->withCommands(['pwd'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("/tmp\n", $instance->getOutput());
@@ -212,6 +228,7 @@ class GenericContainerTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withStartupTimeout(1)
             ->withCommands(['sleep', '5']);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
     }
 
@@ -219,6 +236,7 @@ class GenericContainerTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withPrivilegedMode(true);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame(true, $instance->getPrivilegedMode());

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -229,7 +229,7 @@ class GenericContainerTest extends TestCase
             ->withStartupTimeout(1)
             ->withCommands(['sleep', '5']);
         /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
+        $container->start();
     }
 
     public function testStartWithPrivilegedMode()

--- a/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\Containers\StartupCheckStrategy;
 
 use PHPUnit\Framework\TestCase;
-use Testcontainers\Containers\GenericContainerInstance;
 use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategy;
 use Testcontainers\Docker\DockerClient;
 


### PR DESCRIPTION
This pull request includes various code improvements and cleanup across multiple files. The changes primarily focus on simplifying the code by using the shorthand ternary operator, removing unused imports, and adding comments to suppress inspection warnings in test cases.

Code simplification:
* `src/Containers/GenericContainer.php`, `src/Containers/GenericContainerInstance.php`, `src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php`: Replaced the ternary operator with the shorthand ternary operator `?:` for cleaner code. [[1]](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1L1003-R1003) [[2]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL197-R197) [[3]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL207-R207) [[4]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL242-R242) [[5]](diffhunk://#diff-44186c49b31cd17536ed5d0871258315782a7d8d3b130fa7121f927321506d8cL263-R263) [[6]](diffhunk://#diff-0ea982ceb5fe8735c26b86d88e8766c6d311eec67cc1d244ceec6d316a63375eL25-R25)

Code cleanup:
* [`src/Docker/Types/State.php`](diffhunk://#diff-9dcc0aebb789dd0d1f4f604f119ea247870ab71abf62ea0b258e411b1dcb3704L5-L6): Removed unused imports `DateTime` and `Exception`.
* [`src/Exceptions/InvalidFormatException.php`](diffhunk://#diff-ed1217ab3f49be6a7b886577ffc20d1df779bad2c5089561116ec7402a4a25b9L25): Removed an unnecessary assignment of the `$message` variable.

Test improvements:
* `tests/Unit/Containers/GenericContainerInstanceTest.php`, `tests/Unit/Containers/GenericContainerTest.php`: Added comments to suppress inspection warnings for unhandled exceptions in test cases. [[1]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R82) [[2]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R96) [[3]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R22) [[4]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R40) [[5]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R55-R62) [[6]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R72) [[7]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R83) [[8]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R94) [[9]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R105) [[10]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R128) [[11]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R140) [[12]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R152) [[13]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R163) [[14]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R176) [[15]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R190) [[16]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R206) [[17]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R218) [[18]](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L215-R239)

Code cleanup in tests:
* [`tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php`](diffhunk://#diff-6ab13555417bb70db499853529a895b83fdf8bfbf3e28f2c18f10c54d41ce703L6): Removed an unused import `GenericContainerInstance`.