### PR TITLE
Refactor Docker command handling with traits and improved test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,4 +176,8 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/composer,symfony,phpstorm+all,phpunit,phpcodesniffer
 
+# Composer
 composer.lock
+
+# Qodo
+.qodo/

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -8,6 +8,7 @@ use Testcontainers\Docker\Exception\DockerException;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
 use Testcontainers\Docker\Exception\NoSuchObjectException;
 use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
+
 use function Testcontainers\kebab;
 
 /**

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Testcontainers\Docker\Command;
+
+use LogicException;
+use Symfony\Component\Process\Process;
+use Testcontainers\Docker\Exception\DockerException;
+use Testcontainers\Docker\Exception\NoSuchContainerException;
+use Testcontainers\Docker\Exception\NoSuchObjectException;
+use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
+use function Testcontainers\kebab;
+
+/**
+ * Base command for Docker commands.
+ *
+ * This trait provides common functionality for executing Docker commands using the Symfony Process component.
+ * It allows you to set the Docker command path, global options, working directory, environment variables,
+ * input, timeout, and process options for Docker commands.
+ */
+trait BaseCommand
+{
+    /**
+     * The command used to interact with Docker.
+     *
+     * @var string The Docker command, default is 'docker'.
+     */
+    private $command = 'docker';
+
+    /**
+     * Global options for Docker commands.
+     *
+     * These options are applied to all Docker commands executed by this client.
+     *
+     * @var array
+     */
+    private $options = [];
+
+    /**
+     * The working directory for Docker commands.
+     *
+     * This directory is used as the current working directory for all Docker commands
+     * executed by this client. If set to null, the current PHP process directory is used.
+     *
+     * @var null|string The working directory path or null if not set.
+     */
+    private $cwd = null;
+
+    /**
+     * Environment variables for Docker commands.
+     *
+     * These variables are passed to the Docker process when executing commands.
+     * If set to null, the current environment variables of the PHP process are used.
+     *
+     * @var array An associative array of environment variables or null if not set.
+     */
+    private $env = [];
+
+    /**
+     * The input for Docker commands.
+     *
+     * This can be a stream resource, scalar value, `\Traversable`, or null if no input is provided.
+     *
+     * @var mixed|null
+     */
+    private $input = null;
+
+    /**
+     * The timeout for Docker commands.
+     *
+     * This value represents the maximum time in seconds that a Docker command is allowed to run.
+     * If set to null, the command will run indefinitely without timing out.
+     *
+     * @var int|float|null The timeout in seconds, or null to disable the timeout.
+     */
+    private $timeout = 60;
+
+    /**
+     * Options for the `proc_open` function.
+     *
+     * These options are used when creating a new process using the `proc_open` function.
+     * Refer to the PHP documentation for `proc_open` for more details on available options.
+     *
+     * @var array
+     */
+    private $proc_options = [];
+
+    /**
+     * Set the Docker command path.
+     *
+     * This method allows you to specify the path to the Docker command
+     * that will be used by this client. By default, it is set to 'docker'.
+     *
+     * @param string $command The path to the Docker command.
+     * @return self
+     */
+    public function withCommand($command)
+    {
+        $this->command = $command;
+
+        return $this;
+    }
+
+    /**
+     * Set global Docker options.
+     *
+     * This method allows you to specify global options that will be applied to all Docker commands
+     * executed by this client. These options can include flags and parameters that modify the behavior
+     * of Docker commands.
+     *
+     * @param array $options An associative array of Docker global options.
+     * @return self
+     */
+    public function withGlobalOptions($options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Set the working directory for Docker commands.
+     *
+     * This method sets the directory that will be used as the current working directory
+     * for all Docker commands executed by this client. If not set, the current PHP process
+     * directory will be used.
+     *
+     * @param null|string $cwd The path to the working directory.
+     * @return self
+     */
+    public function withCwd($cwd)
+    {
+        $this->cwd = $cwd;
+
+        return $this;
+    }
+
+    /**
+     * Set environment variables for Docker commands.
+     *
+     * This method allows you to specify environment variables that will be passed
+     * to the Docker process when executing commands. If not set, the current
+     * environment variables of the PHP process will be used.
+     *
+     * @param array $env An associative array of environment variables.
+     * @return self
+     */
+    public function withEnv($env)
+    {
+        $this->env = $env;
+
+        return $this;
+    }
+
+    /**
+     * Set the input for Docker commands.
+     *
+     * This method allows you to specify the input that will be passed to the Docker process
+     * when executing commands. The input can be a stream resource, a scalar value, a `\Traversable`,
+     * or `null` if no input is provided.
+     *
+     * @param null|mixed $input The input for the Docker process.
+     * @return self
+     */
+    public function withInput($input)
+    {
+        $this->input = $input;
+
+        return $this;
+    }
+
+    /**
+     * Set the timeout for Docker commands.
+     *
+     * This method allows you to specify the maximum time in seconds that a Docker command is allowed to run.
+     * If set to `null`, the command will run indefinitely without timing out.
+     *
+     * @param int|float|null $timeout The timeout in seconds, or `null` to disable the timeout.
+     * @return self
+     */
+    public function withTimeout($timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Set options for the `proc_open` function.
+     *
+     * This method allows you to specify options that will be used when creating a new process
+     * using the `proc_open` function. Refer to the PHP documentation for `proc_open` for more details
+     * on available options.
+     *
+     * @param array $proc_options An associative array of options for `proc_open`.
+     * @return self
+     */
+    public function withProcOptions($proc_options)
+    {
+        $this->proc_options = $proc_options;
+
+        return $this;
+    }
+
+    /**
+     * Execute a Docker command.
+     *
+     * @param string $command The command to execute.
+     * @param string|null $subcommand The subcommand to execute (optional).
+     * @param array $args The arguments for the command (optional).
+     * @param array $options Additional options for the Docker command.
+     * @return Process The Symfony Process instance that was executed
+     *
+     * @throws NoSuchContainerException If the specified container does not exist.
+     * @throws NoSuchObjectException If the specified object does not exist.
+     * @throws PortAlreadyAllocatedException If the specified port is already allocated.
+     * @throws DockerException If the Docker command fails.
+     */
+    protected function execute($command, $subcommand = null, $args = [], $options = [])
+    {
+        // docker [global options] command [subcommand] [options] [args]
+        $commandLine = ['docker'];
+        if (count($this->options) > 0) {
+            $commandLine = array_merge($commandLine, $this->arrayToArgs($this->options));
+        }
+        $commandLine[] = $command;
+        if ($subcommand) {
+            $commandLine[] = $subcommand;
+        }
+        if (count($options) > 0) {
+            $commandLine = array_merge($commandLine, $this->arrayToArgs($options));
+        }
+        if (count($args) > 0) {
+            $commandLine = array_merge($commandLine, $args);
+        }
+        $process = new Process(
+            $commandLine,
+            $this->cwd,
+            $this->env,
+            $this->input,
+            $this->timeout,
+            $this->proc_options
+        );
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            $stderr = $process->getErrorOutput();
+            if (NoSuchContainerException::match($stderr)) {
+                throw new NoSuchContainerException($process);
+            } elseif (NoSuchObjectException::match($stderr)) {
+                throw new NoSuchObjectException($process);
+            } elseif (PortAlreadyAllocatedException::match($stderr)) {
+                throw new PortAlreadyAllocatedException($process);
+            }
+            throw new DockerException($process);
+        }
+
+        return $process;
+    }
+
+    /**
+     * Convert array to command line arguments
+     *
+     * @param array $options command line options (key-value pairs)
+     * @return array
+     */
+    private function arrayToArgs($options)
+    {
+        $result = [];
+        foreach ($options as $key => $value) {
+            $key = kebab($key);
+            if ($value === null) {
+                continue;
+            }
+            if ($value === false) {
+                continue;
+            }
+            if ($value === true) {
+                $result[] = "--$key";
+                continue;
+            }
+            if (is_scalar($value)) {
+                $result[] = "--$key";
+                $result[] = $value;
+                continue;
+            }
+            if (is_array($value)) {
+                foreach ($value as $k => $v) {
+                    $result[] = "--$key";
+                    if (is_string($k)) {
+                        $result[] = "$k=$v";
+                    } elseif (is_scalar($v) && !is_bool($v)) {
+                        $result[] = $v;
+                    } elseif (method_exists($v, '__toString')) {
+                        $result[] = (string) $v;
+                    } else {
+                        throw new LogicException('Unsupported value type: `' . var_export($v, true) . '`');
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Docker/Command/RunCommand.php
+++ b/src/Docker/Command/RunCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Testcontainers\Docker\Command;
+
+use Testcontainers\Docker\DockerRunOutput;
+use Testcontainers\Docker\DockerRunWithDetachOutput;
+use Testcontainers\Docker\Exception\DockerException;
+use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
+
+/**
+ * Run command for Docker commands.
+ *
+ * This trait provides functionality for creating and running a new container from a Docker image.
+ */
+trait RunCommand
+{
+    /**
+     * Create and run a new container from a Docker image.
+     *
+     * This method wraps the `docker run` command to create and run a new container from a specified Docker image.
+     *
+     * @param string $image The name of the Docker image to use.
+     * @param string|null $command The command to run inside the container (optional).
+     * @param array $args The arguments for the command (optional).
+     * @param array{
+     *     addHost?: string[],
+     *     detach?: bool,
+     *     env?: array<string, string>,
+     *     label?: string[],
+     *     mount?: string[],
+     *     network?: string,
+     *     networkAlias?: string[],
+     *     privileged?: bool,
+     *     publish?: string[],
+     *     pull?: string,
+     *     quiet?: true,
+     *     volumesFrom?: string[],
+     *     workdir?: string,
+     * } $options Additional options for the Docker command.
+     * @return DockerRunOutput|DockerRunWithDetachOutput The output of the Docker run command. If the `detach` option is set to `true`, a `DockerRunWithDetachOutput` object is returned.
+     *
+     * @throws PortAlreadyAllocatedException If the specified port is already allocated.
+     * @throws DockerException If the Docker command fails.
+     */
+    public function run($image, $command = null, $args = [], $options = [])
+    {
+        $process = $this->execute(
+            'run',
+            null,
+            array_filter(array_merge([$image, $command], $args)),
+            $options
+        );
+        if (isset($options['detach']) && $options['detach'] === true) {
+            return new DockerRunWithDetachOutput($process);
+        } else {
+            return new DockerRunOutput($process);
+        }
+    }
+
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = []);
+}

--- a/src/Docker/DockerClient.php
+++ b/src/Docker/DockerClient.php
@@ -3,14 +3,14 @@
 namespace Testcontainers\Docker;
 
 use Symfony\Component\Process\Process;
+use Testcontainers\Docker\Command\BaseCommand;
+use Testcontainers\Docker\Command\RunCommand;
 use Testcontainers\Docker\Exception\DockerException;
 use Testcontainers\Docker\Exception\InvalidValueException;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
 use Testcontainers\Docker\Exception\NoSuchObjectException;
-use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
 
 use function Testcontainers\array_flatten;
-use function Testcontainers\kebab;
 
 /**
  * A client for interacting with Docker.
@@ -20,239 +20,8 @@ use function Testcontainers\kebab;
  */
 class DockerClient
 {
-    /**
-     * The command used to interact with Docker.
-     *
-     * @var string The Docker command, default is 'docker'.
-     */
-    private $command = 'docker';
-
-    /**
-    * Global options for Docker commands.
-    *
-    * These options are applied to all Docker commands executed by this client.
-    *
-    * @var array
-    */
-    private $options = [];
-
-    /**
-     * The working directory for Docker commands.
-     *
-     * This directory is used as the current working directory for all Docker commands
-     * executed by this client. If set to null, the current PHP process directory is used.
-     *
-     * @var null|string The working directory path or null if not set.
-     */
-    private $cwd = null;
-
-    /**
-     * Environment variables for Docker commands.
-     *
-     * These variables are passed to the Docker process when executing commands.
-     * If set to null, the current environment variables of the PHP process are used.
-     *
-     * @var array An associative array of environment variables or null if not set.
-     */
-    private $env = [];
-
-    /**
-     * The input for Docker commands.
-     *
-     * This can be a stream resource, scalar value, `\Traversable`, or null if no input is provided.
-     *
-     * @var mixed|null
-     */
-    private $input = null;
-
-    /**
-     * The timeout for Docker commands.
-     *
-     * This value represents the maximum time in seconds that a Docker command is allowed to run.
-     * If set to null, the command will run indefinitely without timing out.
-     *
-     * @var int|float|null The timeout in seconds, or null to disable the timeout.
-     */
-    private $timeout = 60;
-
-    /**
-     * Options for the `proc_open` function.
-     *
-     * These options are used when creating a new process using the `proc_open` function.
-     * Refer to the PHP documentation for `proc_open` for more details on available options.
-     *
-     * @var array
-     */
-    private $proc_options = [];
-
-    /**
-     * Set the Docker command path.
-     *
-     * This method allows you to specify the path to the Docker command
-     * that will be used by this client. By default, it is set to 'docker'.
-     *
-     * @param string $command The path to the Docker command.
-     * @return self
-     */
-    public function withCommand($command)
-    {
-        $this->command = $command;
-
-        return $this;
-    }
-
-    /**
-     * Set global Docker options.
-     *
-     * This method allows you to specify global options that will be applied to all Docker commands
-     * executed by this client. These options can include flags and parameters that modify the behavior
-     * of Docker commands.
-     *
-     * @param array $options An associative array of Docker global options.
-     * @return self
-     */
-    public function withGlobalOptions($options)
-    {
-        $this->options = $options;
-
-        return $this;
-    }
-
-    /**
-     * Set the working directory for Docker commands.
-     *
-     * This method sets the directory that will be used as the current working directory
-     * for all Docker commands executed by this client. If not set, the current PHP process
-     * directory will be used.
-     *
-     * @param null|string $cwd The path to the working directory.
-     * @return self
-     */
-    public function withCwd($cwd)
-    {
-        $this->cwd = $cwd;
-
-        return $this;
-    }
-
-    /**
-     * Set environment variables for Docker commands.
-     *
-     * This method allows you to specify environment variables that will be passed
-     * to the Docker process when executing commands. If not set, the current
-     * environment variables of the PHP process will be used.
-     *
-     * @param array $env An associative array of environment variables.
-     * @return self
-     */
-    public function withEnv($env)
-    {
-        $this->env = $env;
-
-        return $this;
-    }
-
-    /**
-     * Set the input for Docker commands.
-     *
-     * This method allows you to specify the input that will be passed to the Docker process
-     * when executing commands. The input can be a stream resource, a scalar value, a `\Traversable`,
-     * or `null` if no input is provided.
-     *
-     * @param null|mixed $input The input for the Docker process.
-     * @return self
-     */
-    public function withInput($input)
-    {
-        $this->input = $input;
-
-        return $this;
-    }
-
-    /**
-     * Set the timeout for Docker commands.
-     *
-     * This method allows you to specify the maximum time in seconds that a Docker command is allowed to run.
-     * If set to `null`, the command will run indefinitely without timing out.
-     *
-     * @param int|float|null $timeout The timeout in seconds, or `null` to disable the timeout.
-     * @return self
-     */
-    public function withTimeout($timeout)
-    {
-        $this->timeout = $timeout;
-
-        return $this;
-    }
-
-    /**
-     * Set options for the `proc_open` function.
-     *
-     * This method allows you to specify options that will be used when creating a new process
-     * using the `proc_open` function. Refer to the PHP documentation for `proc_open` for more details
-     * on available options.
-     *
-     * @param array $proc_options An associative array of options for `proc_open`.
-     * @return self
-     */
-    public function withProcOptions($proc_options)
-    {
-        $this->proc_options = $proc_options;
-
-        return $this;
-    }
-
-    /**
-     * Create and run a new container from a Docker image.
-     *
-     * This method wraps the `docker run` command to create and run a new container from a specified Docker image.
-     *
-     * @param string $image The name of the Docker image to use.
-     * @param string|null $command The command to run inside the container (optional).
-     * @param array|null $args The arguments for the command (optional).
-     * @param array $options Additional options for the Docker command.
-     * @return DockerRunOutput|DockerRunWithDetachOutput The output of the Docker run command. If the `detach` option is set to `true`, a `DockerRunWithDetachOutput` object is returned.
-     *
-     * @throws PortAlreadyAllocatedException If the specified port is already allocated.
-     * @throws DockerException If the Docker command fails.
-     */
-    public function run($image, $command = null, $args = null, $options = [])
-    {
-        $commandline = array_filter(array_flatten([
-            $this->command,
-            $this->arrayToArgs($this->options),
-            'run',
-            $this->arrayToArgs($options),
-            $image,
-            $command,
-            $args,
-        ]));
-        $process = new Process(
-            $commandline,
-            $this->cwd,
-            $this->env,
-            $this->input,
-            $this->timeout,
-            $this->proc_options
-        );
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $stderr = $process->getErrorOutput();
-            if (PortAlreadyAllocatedException::match($stderr)) {
-                throw new PortAlreadyAllocatedException($process);
-            }
-            throw new DockerException($process);
-        }
-
-        if (isset($options['detach']) && $options['detach'] === true) {
-            $stdout = $process->getOutput();
-            $containerId = trim($stdout);
-            return new DockerRunWithDetachOutput($process, $containerId);
-        } else {
-            return new DockerRunOutput($process);
-        }
-    }
+    use BaseCommand;
+    use RunCommand;
 
     /**
      * Inspect a Docker container.
@@ -503,47 +272,6 @@ class DockerClient
         }
 
         return new DockerNetworkCreateOutput($process);
-    }
-
-    /**
-     * Convert array to command line arguments
-     *
-     * @param array $options command line options (key-value pairs)
-     * @return array
-     */
-    private function arrayToArgs($options)
-    {
-        $result = [];
-        foreach ($options as $key => $value) {
-            $key = kebab($key);
-            if ($value === null) {
-                continue;
-            }
-            if ($value === false) {
-                continue;
-            }
-            if ($value === true) {
-                $result[] = "--$key";
-                continue;
-            }
-            if (is_scalar($value)) {
-                $result[] = "--$key";
-                $result[] = $value;
-                continue;
-            }
-            if (is_array($value)) {
-                foreach ($value as $k => $v) {
-                    $result[] = "--$key";
-                    if (is_string($k)) {
-                        $result[] = "$k=$v";
-                    } elseif (is_scalar($v) && !is_bool($v)) {
-                        $result[] = $v;
-                    }
-                }
-            }
-        }
-
-        return $result;
     }
 
     public function __clone()

--- a/src/Docker/DockerRunWithDetachOutput.php
+++ b/src/Docker/DockerRunWithDetachOutput.php
@@ -3,6 +3,7 @@
 namespace Testcontainers\Docker;
 
 use Symfony\Component\Process\Process;
+use Testcontainers\Docker\Types\ContainerId;
 
 /**
  * Represents the output of a Docker `run` command executed via Symfony Process.
@@ -23,14 +24,13 @@ class DockerRunWithDetachOutput extends DockerRunOutput
     private $containerId;
 
     /**
-     * @param Process $process
-     * @param string $containerId
+     * @param Process $process The Symfony Process instance that executed the `docker run` command.
      */
-    public function __construct($process, $containerId)
+    public function __construct($process)
     {
         parent::__construct($process);
 
-        $this->containerId = $containerId;
+        $this->containerId = new ContainerId(trim($process->getOutput()));
     }
 
     /**

--- a/src/Docker/Exception/DockerException.php
+++ b/src/Docker/Exception/DockerException.php
@@ -29,7 +29,7 @@ class DockerException extends RuntimeException
         $exitCode = $process->getExitCode();
         parent::__construct(
             sprintf(
-                "Failed to docker command: `%s`, exit code: `%s`, stderr: %s",
+                "Failed to docker command: `%s`, exit code: `%s`, stderr: `%s`",
                 $command,
                 $exitCode,
                 $process->getErrorOutput()

--- a/src/Docker/Exception/PortAlreadyAllocatedException.php
+++ b/src/Docker/Exception/PortAlreadyAllocatedException.php
@@ -19,7 +19,7 @@ class PortAlreadyAllocatedException extends DockerException
      */
     public static function match($output)
     {
-        return preg_match('/Error response from daemon: /', $output) !== false
-            && preg_match('/port is already allocated\.$/', $output) !== false;
+        return strpos($output, 'Error response from daemon:') !== false
+            && strpos($output, 'port is already allocated.') !== false;
     }
 }

--- a/src/Docker/Types/ContainerId.php
+++ b/src/Docker/Types/ContainerId.php
@@ -48,7 +48,7 @@ class ContainerId
             return false;
         }
         if (preg_match('/^[a-f0-9]{12}$/', $v) !== 1
-            || preg_match('/^[a-f0-9]{64}$/', $v) !== 1) {
+            && preg_match('/^[a-f0-9]{64}$/', $v) !== 1) {
             return false;
         }
         return true;

--- a/src/Docker/Types/ContainerId.php
+++ b/src/Docker/Types/ContainerId.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Testcontainers\Docker\Types;
+
+use InvalidArgumentException;
+use LogicException;
+
+/**
+ * Represents the ID of a Docker container.
+ *
+ * This class is a value object that represents the ID of a Docker container.
+ * The container ID is a 64-character hexadecimal string that uniquely identifies
+ * a Docker container on the host system.
+ */
+class ContainerId
+{
+    /**
+     * The ID of the Docker container.
+     * @var string
+     */
+    private $data;
+
+    /**
+     * @param string $v
+     * @throws InvalidArgumentException If the container ID is not a valid 64-character hexadecimal string.
+     */
+    public function __construct($v)
+    {
+        if (!self::isValid($v)) {
+            throw new LogicException('Invalid container ID: `' . $v . '`');
+        }
+
+        $this->data = $v;
+    }
+
+    /**
+     * Check if the container ID is valid.
+     *
+     * This method checks if the given value is a valid container ID.
+     * A valid container ID is a 64-character hexadecimal string.
+     *
+     * @param mixed $v The value to check.
+     * @return bool True if the value is a valid container ID, false otherwise.
+     */
+    public static function isValid($v)
+    {
+        if (!is_string($v)) {
+            return false;
+        }
+        if (preg_match('/^[a-f0-9]{12}$/', $v) !== 1
+            || preg_match('/^[a-f0-9]{64}$/', $v) !== 1) {
+            return false;
+        }
+        return true;
+    }
+
+    public static function fromString($v)
+    {
+        if (!self::isValid($v)) {
+            throw new InvalidArgumentException('Invalid container ID: `' . $v . '`');
+        }
+        return new self($v);
+    }
+
+    /**
+     * Get the container ID.
+     *
+     * @return string The container ID.
+     */
+    public function toString()
+    {
+        return $this->__toString();
+    }
+
+    /**
+     * @return string The container ID.
+     */
+    public function __toString()
+    {
+        return $this->data;
+    }
+}

--- a/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
@@ -18,7 +18,7 @@ abstract class StartupCheckStrategyTestCase extends TestCase
         $strategy = $this->resolveStartupCheckStrategy();
 
         $client = new DockerClient();
-        $output = $client->run('alpine:latest', null, null, [
+        $output = $client->run('alpine:latest', null, [], [
             'detach' => true,
         ]);
         $containerId = $output->getContainerId();

--- a/tests/Unit/Containers/WaitStrategy/LogMessageWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/LogMessageWaitStrategyTest.php
@@ -19,7 +19,7 @@ class LogMessageWaitStrategyTest extends WaitStrategyTestCase
     public function testWaitUntilReady()
     {
         $client = new DockerClient();
-        $output = $client->run('jpetazzo/clock:latest', null, null, [
+        $output = $client->run('jpetazzo/clock:latest', null, [], [
             'detach' => true,
         ]);
         $containerId = $output->getContainerId();

--- a/tests/Unit/Docker/Command/RunCommandTest.php
+++ b/tests/Unit/Docker/Command/RunCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\Docker\Command;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Docker\Command\RunCommand;
+use Testcontainers\Docker\DockerClient;
+use Testcontainers\Docker\DockerRunOutput;
+use Testcontainers\Docker\DockerRunWithDetachOutput;
+use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
+use Testcontainers\Testcontainers;
+use Tests\Images\DinD;
+
+class RunCommandTest extends TestCase
+{
+    public function testHasRunCommandTrait()
+    {
+        $uses = class_uses(DockerClient::class);
+
+        $this->assertContains(RunCommand::class, $uses);
+    }
+
+    public function testRun()
+    {
+        $client = new DockerClient();
+        $output = $client->run('alpine:latest', 'echo', ['Hello, World!']);
+
+        $this->assertInstanceOf(DockerRunOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertSame("Hello, World!\n", $output->getOutput());
+    }
+
+    public function testRunWithDetach()
+    {
+        $client = new DockerClient();
+        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
+            'detach' => true,
+        ]);
+
+        $this->assertInstanceOf(DockerRunWithDetachOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertNotEmpty($output->getContainerId());
+    }
+
+    public function testRunWithTrueOptions()
+    {
+        $client = new DockerClient();
+        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
+            'quiet' => true,
+        ]);
+
+        $this->assertInstanceOf(DockerRunOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertSame("Hello, World!\n", $output->getOutput());
+    }
+
+    public function testRunWithFalseOptions()
+    {
+        $client = new DockerClient();
+        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
+            'detach' => false,
+        ]);
+
+        $this->assertInstanceOf(DockerRunOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertSame("Hello, World!\n", $output->getOutput());
+    }
+
+    public function testRunWithArrayOptions()
+    {
+        $client = new DockerClient();
+        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
+            'publish' => ['38621:80', '38622:443'],
+        ]);
+
+        $this->assertInstanceOf(DockerRunOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertSame("Hello, World!\n", $output->getOutput());
+    }
+
+    public function testRunWithObjectOptions()
+    {
+        $client = new DockerClient();
+        $output = $client->run('alpine:latest', 'printenv', ['BAR'], [
+            'env' => [
+                'FOO' => 'foo',
+                'BAR' => 'bar',
+            ],
+        ]);
+
+        $this->assertInstanceOf(DockerRunOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertSame("bar\n", $output->getOutput());
+    }
+
+    public function testRunWithPortConflict()
+    {
+        $this->expectException(PortAlreadyAllocatedException::class);
+
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = new DockerClient();
+        $client->withGlobalOptions([
+            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
+        ]);
+        $client->run('alpine:latest', null, ['tail', '-f', '/dev/null'], [
+            'detach' => true,
+            'publish' => ['38793:80'],
+        ]);
+        $client->run('alpine:latest', null, ['tail', '-f', '/dev/null'], [
+            'detach' => true,
+            'publish' => ['38793:80'],
+        ]);
+    }
+}

--- a/tests/Unit/Docker/DockerClientTest.php
+++ b/tests/Unit/Docker/DockerClientTest.php
@@ -9,109 +9,13 @@ use Testcontainers\Docker\DockerInspectOutput;
 use Testcontainers\Docker\DockerLogsOutput;
 use Testcontainers\Docker\DockerNetworkCreateOutput;
 use Testcontainers\Docker\DockerProcessStatusOutput;
-use Testcontainers\Docker\DockerRunOutput;
-use Testcontainers\Docker\DockerRunWithDetachOutput;
 use Testcontainers\Docker\DockerStopOutput;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
-use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
 class DockerClientTest extends TestCase
 {
-    public function testRun()
-    {
-        $client = new DockerClient();
-        $output = $client->run('alpine:latest', 'echo', ['Hello, World!']);
-
-        $this->assertInstanceOf(DockerRunOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertSame("Hello, World!\n", $output->getOutput());
-    }
-
-    public function testRunWithDetach()
-    {
-        $client = new DockerClient();
-        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
-            'detach' => true,
-        ]);
-
-        $this->assertInstanceOf(DockerRunWithDetachOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertNotEmpty($output->getContainerId());
-    }
-
-    public function testRunWithTrueOptions()
-    {
-        $client = new DockerClient();
-        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
-            'quiet' => true,
-        ]);
-
-        $this->assertInstanceOf(DockerRunOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertSame("Hello, World!\n", $output->getOutput());
-    }
-
-    public function testRunWithFalseOptions()
-    {
-        $client = new DockerClient();
-        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
-            'detach' => false,
-        ]);
-
-        $this->assertInstanceOf(DockerRunOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertSame("Hello, World!\n", $output->getOutput());
-    }
-
-    public function testRunWithArrayOptions()
-    {
-        $client = new DockerClient();
-        $output = $client->run('alpine:latest', 'echo', ['Hello, World!'], [
-            'publish' => ['38621:80', '38622:443'],
-        ]);
-
-        $this->assertInstanceOf(DockerRunOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertSame("Hello, World!\n", $output->getOutput());
-    }
-
-    public function testRunWithObjectOptions()
-    {
-        $client = new DockerClient();
-        $output = $client->run('alpine:latest', 'printenv', ['BAR'], [
-            'env' => [
-                'FOO' => 'foo',
-                'BAR' => 'bar',
-            ],
-        ]);
-
-        $this->assertInstanceOf(DockerRunOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertSame("bar\n", $output->getOutput());
-    }
-
-    public function testRunWithPortConflict()
-    {
-        $this->expectException(PortAlreadyAllocatedException::class);
-
-        $instance = Testcontainers::run(DinD::class);
-
-        $client = new DockerClient();
-        $client->withGlobalOptions([
-            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
-        ]);
-        $client->run('nginx:1.27.2', null, null, [
-            'detach' => true,
-            'publish' => ['38793:80'],
-        ]);
-        $client->run('nginx:1.27.2', null, null, [
-            'detach' => true,
-            'publish' => ['38793:80'],
-        ]);
-    }
-
     public function testInspect()
     {
         $client = new DockerClient();
@@ -181,7 +85,7 @@ class DockerClientTest extends TestCase
         $client->withGlobalOptions([
             'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
         ]);
-        $output = $client->run('jpetazzo/clock:latest', null, null, [
+        $output = $client->run('jpetazzo/clock:latest', null, [], [
             'detach' => true,
         ]);
 
@@ -201,7 +105,7 @@ class DockerClientTest extends TestCase
         $client->withGlobalOptions([
             'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
         ]);
-        $output = $client->run('jpetazzo/clock:latest', null, null, [
+        $output = $client->run('jpetazzo/clock:latest', null, [], [
             'detach' => true,
         ]);
 


### PR DESCRIPTION
This pull request introduces significant changes to the Docker command handling within the codebase. The main updates include the addition of `BaseCommand` and `RunCommand` traits, the refactoring of the `DockerClient` class to use these traits, and improvements to exception handling and output processing.

### New Traits for Docker Commands:
* [`src/Docker/Command/BaseCommand.php`](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R1-R304): Introduced the `BaseCommand` trait to provide common functionality for executing Docker commands using the Symfony Process component. This includes methods for setting command paths, global options, environment variables, input, timeout, and process options.
* [`src/Docker/Command/RunCommand.php`](diffhunk://#diff-004f9b58cf5a76a41c0b5bc78283c320751aab57b7bd953392e7b0adcbe5363aR1-R61): Introduced the `RunCommand` trait to provide functionality for creating and running a new container from a Docker image. This trait includes the `run` method to wrap the `docker run` command.

### Refactoring DockerClient:
* [`src/Docker/DockerClient.php`](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4L23-R24): Refactored the `DockerClient` class to use the newly introduced `BaseCommand` and `RunCommand` traits, removing redundant code and simplifying the class. [[1]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4L23-R24) [[2]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4L508-L548)

### Exception Handling and Output Processing:
* [`src/Docker/Exception/PortAlreadyAllocatedException.php`](diffhunk://#diff-360a485a396d4282d7030e4eb682845cc04f675e4b1e5168153c6723f8866ea7L22-R23): Updated the `match` method to use `strpos` for better performance and readability.
* [`src/Docker/DockerRunWithDetachOutput.php`](diffhunk://#diff-358c7d13a8e0374ea8ea61f52375ad53f76d8c0ecd4ee8888da086923680a406L26-R33): Improved the constructor to use the `ContainerId` type for better type safety and clarity.
* [`src/Docker/Exception/DockerException.php`](diffhunk://#diff-34e51d58d5b8b01705a7296ffdeb011befa9f4fb351014360d5c3acc1ddedafdL32-R32): Fixed a formatting issue in the exception message.