### PR TITLE
Introduce StopCommand trait and refactor Docker stop functionality

### DIFF
--- a/src/Docker/Command/StopCommand.php
+++ b/src/Docker/Command/StopCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Testcontainers\Docker\Command;
+
+use Testcontainers\Docker\Exception\DockerException;
+use Testcontainers\Docker\Exception\NoSuchContainerException;
+use Testcontainers\Docker\Output\DockerStopOutput;
+use Testcontainers\Docker\Types\ContainerId;
+
+/**
+ * Stop command for Docker command.
+ *
+ * This trait provides a method for stopping one or more running Docker containers using the `docker stop` command.
+ */
+trait StopCommand
+{
+    /**
+     * Stop one or more running Docker containers.
+     *
+     * This method wraps the `docker stop` command to send a stop signal to the specified container(s) to gracefully stop them.
+     *
+     * @param ContainerId|string|array $containerId The ID or an array of IDs of the container(s) to stop.
+     * @param array $options Additional options for the Docker stop command.
+     * @return DockerStopOutput The output of the Docker stop command, including the stopped container IDs.
+     *
+     * @throws NoSuchContainerException If the specified container does not exist.
+     * @throws DockerException If the Docker command fails for any other reason.
+     */
+    public function stop($containerId, $options = [])
+    {
+        if (is_array($containerId)) {
+            $containerIds = array_map('strval', $containerId);
+        } else {
+            $containerIds = [(string) $containerId];
+        }
+
+        $process = $this->execute(
+            'stop',
+            null,
+            $containerIds,
+            $options
+        );
+
+        return new DockerStopOutput($process);
+    }
+
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = []);
+}

--- a/src/Docker/Output/DockerRunWithDetachOutput.php
+++ b/src/Docker/Output/DockerRunWithDetachOutput.php
@@ -19,7 +19,7 @@ class DockerRunWithDetachOutput extends DockerRunOutput
      * This property holds the container ID of the Docker container that was started
      * by the `docker run` command executed by the Symfony Process instance.
      *
-     * @var string
+     * @var ContainerId
      */
     private $containerId;
 
@@ -39,7 +39,7 @@ class DockerRunWithDetachOutput extends DockerRunOutput
      * This method returns the ID of the Docker container that was started
      * by the `docker run` command executed by the Symfony Process instance.
      *
-     * @return string The Docker container ID.
+     * @return ContainerId The Docker container ID.
      */
     public function getContainerId()
     {

--- a/src/Docker/Output/DockerStopOutput.php
+++ b/src/Docker/Output/DockerStopOutput.php
@@ -3,12 +3,12 @@
 namespace Testcontainers\Docker\Output;
 
 use Symfony\Component\Process\Process;
+use Testcontainers\Docker\Types\ContainerId;
 
 /**
- * Handles the output of a Docker `stop` command executed via Symfony Process.
+ * Represents the output of a Docker `stop` command executed via Symfony Process.
  *
- * This class extends DockerOutput to provide methods for retrieving the IDs
- * of Docker containers that were stopped by the `docker stop` command.
+ * This class extends DockerOutput to include the container IDs of the Docker containers that were stopped
  */
 class DockerStopOutput extends DockerOutput
 {
@@ -18,17 +18,26 @@ class DockerStopOutput extends DockerOutput
      * This property holds the IDs of the Docker containers that were stopped
      * by the `docker stop` command executed by the Symfony Process instance.
      *
-     * @var string[]
+     * @var ContainerId[]
      */
     private $containerIds;
 
     /**
      * @param Process $process
-     * @param string[] $containerIds
      */
-    public function __construct($process, $containerIds)
+    public function __construct($process)
     {
         parent::__construct($process);
+
+        $output = $process->getOutput();
+        $containerIds = [];
+        foreach (explode("\n", $output) as $line) {
+            $line = trim($line);
+            if (empty($line)) {
+                continue;
+            }
+            $containerIds[] = new ContainerId($line);
+        }
 
         $this->containerIds = $containerIds;
     }
@@ -39,7 +48,7 @@ class DockerStopOutput extends DockerOutput
      * This method returns an array of container IDs that were stopped
      * by the `docker stop` command executed by the Symfony Process instance.
      *
-     * @return string[] An array of Docker container IDs.
+     * @return ContainerId[] An array of Docker container IDs.
      */
     public function getContainerIds()
     {

--- a/tests/Unit/Docker/Command/StopCommandTest.php
+++ b/tests/Unit/Docker/Command/StopCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\Docker\Command;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Docker\Command\StopCommand;
+use Testcontainers\Docker\DockerClient;
+use Testcontainers\Docker\Exception\NoSuchContainerException;
+use Testcontainers\Docker\Output\DockerStopOutput;
+use Testcontainers\Testcontainers;
+use Tests\Images\DinD;
+
+class StopCommandTest extends TestCase
+{
+    public function testHasStopCommandTrait()
+    {
+        $uses = class_uses(DockerClient::class);
+
+        $this->assertContains(StopCommand::class, $uses);
+    }
+
+    public function testStop()
+    {
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = new DockerClient();
+        $client->withGlobalOptions([
+            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
+        ]);
+        $output = $client->run('alpine:latest', 'tail', ['-f', '/dev/null'], [
+            'detach' => true,
+        ]);
+        $containerId = $output->getContainerId();
+        $output = $client->stop($containerId);
+
+        $this->assertInstanceOf(DockerStopOutput::class, $output);
+        $this->assertSame(0, $output->getExitCode());
+        $this->assertSame("$containerId\n", $output->getOutput());
+
+        $containerIds = $output->getContainerIds();
+        $this->assertCount(1, $containerIds);
+        $this->assertSame((string) $containerId, (string) $containerIds[0]);
+    }
+
+    public function testStopWithNonExistentContainerId()
+    {
+        $this->expectException(NoSuchContainerException::class);
+
+        $client = new DockerClient();
+        $client->stop('aaaaaaaaaaaa');
+    }
+}

--- a/tests/Unit/Docker/DockerClientTest.php
+++ b/tests/Unit/Docker/DockerClientTest.php
@@ -8,40 +8,11 @@ use Testcontainers\Docker\Output\DockerFollowLogsOutput;
 use Testcontainers\Docker\Output\DockerLogsOutput;
 use Testcontainers\Docker\Output\DockerNetworkCreateOutput;
 use Testcontainers\Docker\Output\DockerProcessStatusOutput;
-use Testcontainers\Docker\Output\DockerStopOutput;
-use Testcontainers\Docker\Exception\NoSuchContainerException;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
 class DockerClientTest extends TestCase
 {
-    public function testStop()
-    {
-        $instance = Testcontainers::run(DinD::class);
-
-        $client = new DockerClient();
-        $client->withGlobalOptions([
-            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
-        ]);
-        $output = $client->run('alpine:latest', 'tail', ['-f', '/dev/null'], [
-            'detach' => true,
-        ]);
-        $containerId = $output->getContainerId();
-        $output = $client->stop($containerId);
-
-        $this->assertInstanceOf(DockerStopOutput::class, $output);
-        $this->assertSame(0, $output->getExitCode());
-        $this->assertSame("$containerId\n", $output->getOutput());
-    }
-
-    public function testStopWithNonExistentContainerId()
-    {
-        $this->expectException(NoSuchContainerException::class);
-
-        $client = new DockerClient();
-        $client->stop('aaaaaaaaaaaa');
-    }
-
     public function testProcessStatus()
     {
         $client = new DockerClient();


### PR DESCRIPTION
This pull request introduces a new `StopCommand` trait for stopping Docker containers, refactors the `DockerClient` class to use this trait, and updates related output handling and tests. The most important changes include the creation of the `StopCommand` trait, updates to the `DockerClient` class, and modifications to the `DockerStopOutput` class.

### New Feature:
* [`src/Docker/Command/StopCommand.php`](diffhunk://#diff-e696a6604e32b542546da21ce200c95b96dcfecfd78dc8bf9102992c2976d15cR1-R48): Added a new `StopCommand` trait to handle stopping Docker containers. This trait provides a method for stopping one or more running Docker containers using the `docker stop` command.

### Refactoring:
* [`src/Docker/DockerClient.php`](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R9-L15): Removed the `stop` method from the `DockerClient` class and replaced it with the `StopCommand` trait. This change simplifies the `DockerClient` class by delegating the stop functionality to the new trait. [[1]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R9-L15) [[2]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4L30-R30)

### Output Handling:
* [`src/Docker/Output/DockerStopOutput.php`](diffhunk://#diff-9e475cca83de82c3cac2d307091a90018593dc66649551b45c4f07d07b6350cbR6-R11): Updated the `DockerStopOutput` class to use the `ContainerId` type for container IDs. This change ensures that container IDs are consistently represented throughout the codebase. [[1]](diffhunk://#diff-9e475cca83de82c3cac2d307091a90018593dc66649551b45c4f07d07b6350cbR6-R11) [[2]](diffhunk://#diff-9e475cca83de82c3cac2d307091a90018593dc66649551b45c4f07d07b6350cbL21-R41) [[3]](diffhunk://#diff-9e475cca83de82c3cac2d307091a90018593dc66649551b45c4f07d07b6350cbL42-R51)

### Testing:
* [`tests/Unit/Docker/Command/StopCommandTest.php`](diffhunk://#diff-edbd0a748adaa6792376065eb830ad8366b0149be452f3d3b8ebc7b840aa10bcR1-R52): Added a new test class for the `StopCommand` trait. This class includes tests for stopping containers and handling non-existent container IDs.
* [`tests/Unit/Docker/DockerClientTest.php`](diffhunk://#diff-a7ad1977a93921a8ba7e543e2249b26aa6092241cd3aff0b537981e2e32e396fL11-L44): Removed the tests for the `stop` method from the `DockerClientTest` class, as these tests are now covered by the `StopCommandTest` class.