### PR TITLE
Introduce LogsCommand trait and refactor Docker log handling

### DIFF
--- a/src/Containers/WaitStrategy/LogMessageWaitStrategy.php
+++ b/src/Containers/WaitStrategy/LogMessageWaitStrategy.php
@@ -2,7 +2,9 @@
 
 namespace Testcontainers\Containers\WaitStrategy;
 
+use LogicException;
 use Testcontainers\Docker\DockerClientFactory;
+use Testcontainers\Docker\Output\DockerFollowLogsOutput;
 
 /**
  * LogMessageWaitStrategy waits until a specified log message is found in the container logs.
@@ -35,7 +37,10 @@ class LogMessageWaitStrategy implements WaitStrategy
         $containerId = $instance->getContainerId();
 
         $client = DockerClientFactory::create();
-        $output = $client->withTimeout($this->timeout)->followLogs($containerId);
+        $output = $client->withTimeout($this->timeout)->logs($containerId, ['follow' => true]);
+        if (!($output instanceof DockerFollowLogsOutput)) {
+            throw new LogicException('Expected DockerFollowLogsOutput instance: `' . get_class($output) . '`');
+        }
         $iter = $output->getIterator();
         $pattern = '/'.str_replace('/', '\/', $this->pattern).'/';
         foreach ($iter as $line) {

--- a/src/Docker/Command/InspectCommand.php
+++ b/src/Docker/Command/InspectCommand.php
@@ -33,5 +33,5 @@ trait InspectCommand
         return new DockerInspectOutput($process);
     }
 
-    abstract protected function execute($command, $subcommand = null, $args = [], $options = []);
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = [], $wait = true);
 }

--- a/src/Docker/Command/LogsCommand.php
+++ b/src/Docker/Command/LogsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Testcontainers\Docker\Command;
+
+use Testcontainers\Docker\Output\DockerFollowLogsOutput;
+use Testcontainers\Docker\Output\DockerLogsOutput;
+use Testcontainers\Docker\Types\ContainerId;
+
+trait LogsCommand
+{
+    /**
+     * Retrieve the logs of a Docker container.
+     *
+     * This method wraps the `docker logs` command to fetch the logs of the specified container.
+     *
+     * @param ContainerId $containerId The ID of the container to fetch logs from.
+     * @param array{
+     *     details?: bool,
+     *     follow?: bool,
+     *     since?: string,
+     *     tail?: string,
+     *     timestamps?: bool,
+     *     until?: string,
+     * } $options Additional options for the Docker logs command.
+     * @return DockerFollowLogsOutput|DockerLogsOutput The output containing the logs of the container.
+     */
+    public function logs($containerId, $options = [])
+    {
+        $follow = isset($options['follow']) ? $options['follow'] : false;
+        $process = $this->execute('logs', null, [(string) $containerId], $options, $follow === false);
+
+        if ($follow === true) {
+            return new DockerFollowLogsOutput($process);
+        } else {
+            return new DockerLogsOutput($process);
+        }
+    }
+
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = [], $wait = true);
+}

--- a/src/Docker/Command/RunCommand.php
+++ b/src/Docker/Command/RunCommand.php
@@ -57,5 +57,5 @@ trait RunCommand
         }
     }
 
-    abstract protected function execute($command, $subcommand = null, $args = [], $options = []);
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = [], $wait = true);
 }

--- a/src/Docker/Command/StopCommand.php
+++ b/src/Docker/Command/StopCommand.php
@@ -44,5 +44,5 @@ trait StopCommand
         return new DockerStopOutput($process);
     }
 
-    abstract protected function execute($command, $subcommand = null, $args = [], $options = []);
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = [], $wait = true);
 }

--- a/src/Docker/DockerClient.php
+++ b/src/Docker/DockerClient.php
@@ -5,12 +5,10 @@ namespace Testcontainers\Docker;
 use Symfony\Component\Process\Process;
 use Testcontainers\Docker\Command\BaseCommand;
 use Testcontainers\Docker\Command\InspectCommand;
+use Testcontainers\Docker\Command\LogsCommand;
 use Testcontainers\Docker\Command\RunCommand;
 use Testcontainers\Docker\Command\StopCommand;
 use Testcontainers\Docker\Exception\DockerException;
-use Testcontainers\Docker\Exception\NoSuchContainerException;
-use Testcontainers\Docker\Output\DockerFollowLogsOutput;
-use Testcontainers\Docker\Output\DockerLogsOutput;
 use Testcontainers\Docker\Output\DockerNetworkCreateOutput;
 
 use function Testcontainers\array_flatten;
@@ -24,82 +22,10 @@ use function Testcontainers\array_flatten;
 class DockerClient
 {
     use BaseCommand;
-    use RunCommand;
     use InspectCommand;
+    use LogsCommand;
+    use RunCommand;
     use StopCommand;
-
-    /**
-     * Retrieve the logs of a Docker container.
-     *
-     * This method wraps the `docker logs` command to fetch the logs of the specified container.
-     *
-     * @param string $containerId The ID of the container to fetch logs from.
-     * @param array $options Additional options for the Docker logs command.
-     * @return DockerLogsOutput The output containing the logs of the container.
-     */
-    public function logs($containerId, $options = [])
-    {
-        $commandline = array_filter(array_flatten([
-            $this->command,
-            $this->arrayToArgs($this->options),
-            'logs',
-            $this->arrayToArgs($options),
-            $containerId,
-        ]));
-        $process = new Process(
-            $commandline,
-            $this->cwd,
-            $this->env,
-            $this->input,
-            $this->timeout,
-            $this->proc_options
-        );
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $stderr = $process->getErrorOutput();
-            if (NoSuchContainerException::match($stderr)) {
-                throw new NoSuchContainerException($process);
-            }
-            throw new DockerException($process);
-        }
-
-        return new DockerLogsOutput($process);
-    }
-
-    /**
-     * Follow the logs of a Docker container.
-     *
-     * This method wraps the `docker logs` command with the `--follow` option to stream the logs
-     * of the specified container in real-time.
-     *
-     * @param string $containerId The ID of the container to follow logs from.
-     * @param array $options Additional options for the Docker logs command.
-     * @return DockerFollowLogsOutput The output containing the streamed logs of the container.
-     */
-    public function followLogs($containerId, $options = [])
-    {
-        $commandline = array_filter(array_flatten([
-            $this->command,
-            $this->arrayToArgs($this->options),
-            'logs',
-            $this->arrayToArgs(array_merge($options, [
-                'follow' => true,
-            ])),
-            $containerId
-        ]));
-        $process = new Process(
-            $commandline,
-            $this->cwd,
-            $this->env,
-            $this->input,
-            $this->timeout,
-            $this->proc_options
-        );
-        $process->start();
-
-        return new DockerFollowLogsOutput($process);
-    }
 
     /**
      * Create a new Docker network.

--- a/tests/Unit/Docker/Command/LogsCommandTest.php
+++ b/tests/Unit/Docker/Command/LogsCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Docker\Command;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Docker\Command\LogsCommand;
+use Testcontainers\Docker\DockerClient;
+use Testcontainers\Docker\Output\DockerFollowLogsOutput;
+use Testcontainers\Docker\Output\DockerLogsOutput;
+use Testcontainers\Testcontainers;
+use Tests\Images\DinD;
+
+class LogsCommandTest extends TestCase
+{
+    public function testHasLogsCommandTrait()
+    {
+        $uses = class_uses(DockerClient::class);
+
+        $this->assertContains(LogsCommand::class, $uses);
+    }
+
+    public function testLogs()
+    {
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = new DockerClient();
+        $client->withGlobalOptions([
+            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
+        ]);
+        $output = $client->run('jpetazzo/clock:latest', null, [], [
+            'detach' => true,
+        ]);
+
+        $containerId = $output->getContainerId();
+        $logsOutput = $client->logs($containerId);
+
+        $this->assertInstanceOf(DockerLogsOutput::class, $logsOutput);
+        $this->assertSame(0, $logsOutput->getExitCode());
+        $this->assertNotEmpty($logsOutput->getOutput());
+    }
+
+    public function testLogsWithFollow()
+    {
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = new DockerClient();
+        $client->withGlobalOptions([
+            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
+        ]);
+        $output = $client->run('jpetazzo/clock:latest', null, [], [
+            'detach' => true,
+        ]);
+
+        $containerId = $output->getContainerId();
+        $logsOutput = $client->logs($containerId, [
+            'follow' => true,
+        ]);
+        $iter = $logsOutput->getIterator();
+
+        $lines = [];
+        for ($i = 0; $i < 3; $i++) {
+            $lines[] = $iter->current();
+            $iter->next();
+        }
+
+        $this->assertInstanceOf(DockerFollowLogsOutput::class, $logsOutput);
+        $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[0]) === 1);
+        $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[1]) === 1);
+        $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[2]) === 1);
+    }
+}

--- a/tests/Unit/Docker/DockerClientTest.php
+++ b/tests/Unit/Docker/DockerClientTest.php
@@ -4,62 +4,12 @@ namespace Tests\Unit\Docker;
 
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Docker\DockerClient;
-use Testcontainers\Docker\Output\DockerFollowLogsOutput;
-use Testcontainers\Docker\Output\DockerLogsOutput;
 use Testcontainers\Docker\Output\DockerNetworkCreateOutput;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
 class DockerClientTest extends TestCase
 {
-    public function testLogs()
-    {
-        $instance = Testcontainers::run(DinD::class);
-
-        $client = new DockerClient();
-        $client->withGlobalOptions([
-            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
-        ]);
-        $output = $client->run('jpetazzo/clock:latest', null, [], [
-            'detach' => true,
-        ]);
-
-        $containerId = $output->getContainerId();
-        $logsOutput = $client->logs($containerId);
-
-        $this->assertInstanceOf(DockerLogsOutput::class, $logsOutput);
-        $this->assertSame(0, $logsOutput->getExitCode());
-        $this->assertNotEmpty($logsOutput->getOutput());
-    }
-
-    public function testFollowLogs()
-    {
-        $instance = Testcontainers::run(DinD::class);
-
-        $client = new DockerClient();
-        $client->withGlobalOptions([
-            'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375),
-        ]);
-        $output = $client->run('jpetazzo/clock:latest', null, [], [
-            'detach' => true,
-        ]);
-
-        $containerId = $output->getContainerId();
-        $logsOutput = $client->followLogs($containerId);
-        $iter = $logsOutput->getIterator();
-
-        $lines = [];
-        for ($i = 0; $i < 3; $i++) {
-            $lines[] = $iter->current();
-            $iter->next();
-        }
-
-        $this->assertInstanceOf(DockerFollowLogsOutput::class, $logsOutput);
-        $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[0]) === 1);
-        $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[1]) === 1);
-        $this->assertTrue(preg_match('/\d{2}:\d{2}:\d{2}/', $lines[2]) === 1);
-    }
-
     public function testNetworkCreate()
     {
         $instance = Testcontainers::run(DinD::class);


### PR DESCRIPTION
This pull request introduces a new `LogsCommand` trait to simplify the handling of Docker container logs and refactors related methods across multiple files. It also includes the addition of a new test class to ensure the correctness of the new `LogsCommand` trait.

### Major Changes:

#### New Feature:
* **Introduction of `LogsCommand` Trait:**
  - Added `LogsCommand` trait to encapsulate the logic for retrieving and following Docker container logs. (`src/Docker/Command/LogsCommand.php`)

#### Refactoring:
* **Refactor Log Handling:**
  - Replaced the existing `logs` and `followLogs` methods in `DockerClient` with the new `LogsCommand` trait. (`src/Docker/DockerClient.php`) [[1]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R8-L13) [[2]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4L27-L103)
  - Updated `LogMessageWaitStrategy` to use the new `logs` method from the `LogsCommand` trait. (`src/Containers/WaitStrategy/LogMessageWaitStrategy.php`)

#### Enhancements:
* **Enhanced `execute` Method:**
  - Modified the `execute` method in `BaseCommand` and related classes to include an optional `$wait` parameter to control whether the process should wait for completion. (`src/Docker/Command/BaseCommand.php`, `src/Docker/Command/InspectCommand.php`, `src/Docker/Command/RunCommand.php`, `src/Docker/Command/StopCommand.php`) [[1]](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R212-R220) [[2]](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R245-L245) [[3]](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R258-R260) [[4]](diffhunk://#diff-9721248b89244953828ec9d6e50ab1f12ebc467c943db75fb4f3c6fc18a32c11L36-R36) [[5]](diffhunk://#diff-004f9b58cf5a76a41c0b5bc78283c320751aab57b7bd953392e7b0adcbe5363aL60-R60) [[6]](diffhunk://#diff-e696a6604e32b542546da21ce200c95b96dcfecfd78dc8bf9102992c2976d15cL47-R47)

#### Testing:
* **New Unit Tests:**
  - Added `LogsCommandTest` to verify the functionality of the `LogsCommand` trait, including tests for both standard log retrieval and following logs. (`tests/Unit/Docker/Command/LogsCommandTest.php`)
  - Removed redundant log tests from `DockerClientTest` since they are now covered by `LogsCommandTest`. (`tests/Unit/Docker/DockerClientTest.php`)