### PR TITLE
docs(StopCommand.php): enhance documentation for Docker stop command …

### DIFF
--- a/src/Docker/Command/StopCommand.php
+++ b/src/Docker/Command/StopCommand.php
@@ -20,7 +20,10 @@ trait StopCommand
      * This method wraps the `docker stop` command to send a stop signal to the specified container(s) to gracefully stop them.
      *
      * @param ContainerId|string|array $containerId The ID or an array of IDs of the container(s) to stop.
-     * @param array $options Additional options for the Docker stop command.
+     * @param array{
+     *     signal?: string,
+     *     time?: int,
+     * } $options Additional options for the Docker stop command.
      * @return DockerStopOutput The output of the Docker stop command, including the stopped container IDs.
      *
      * @throws NoSuchContainerException If the specified container does not exist.


### PR DESCRIPTION
This pull request includes a change to the `StopCommand` trait in the `src/Docker/Command/StopCommand.php` file. The change updates the `$options` parameter to use a more specific array shape for better type hinting and clarity.

* [`src/Docker/Command/StopCommand.php`](diffhunk://#diff-e696a6604e32b542546da21ce200c95b96dcfecfd78dc8bf9102992c2976d15cL23-R26): Updated the `$options` parameter to use an array shape with optional `signal` and `time` keys, improving type hinting and documentation.