### PR TITLE
feat: handle bind address conflicts with new exception

### DIFF
--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -4,6 +4,7 @@ namespace Testcontainers\Docker\Command;
 
 use LogicException;
 use Symfony\Component\Process\Process;
+use Testcontainers\Docker\Exception\BindAddressAlreadyUseException;
 use Testcontainers\Docker\Exception\DockerException;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
 use Testcontainers\Docker\Exception\NoSuchObjectException;
@@ -252,6 +253,8 @@ trait BaseCommand
                     throw new NoSuchObjectException($process);
                 } elseif (PortAlreadyAllocatedException::match($stderr)) {
                     throw new PortAlreadyAllocatedException($process);
+                } elseif (BindAddressAlreadyUseException::match($stderr)) {
+                    throw new BindAddressAlreadyUseException($process);
                 }
                 throw new DockerException($process);
             }

--- a/src/Docker/Exception/BindAddressAlreadyUseException.php
+++ b/src/Docker/Exception/BindAddressAlreadyUseException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Testcontainers\Docker\Exception;
+
+/**
+ * Exception thrown when a bind address is already in use by another process.
+ *
+ * This exception is used to indicate that an attempt to bind an address
+ * has failed because the address is already in use. It extends the DockerException
+ * class to provide additional context specific to address binding conflicts.
+ */
+class BindAddressAlreadyUseException extends DockerException
+{
+    /**
+     * Checks if the given output matches the "bind address already in use" error message.
+     *
+     * @param string $output The output to check.
+     * @return bool True if the output matches the error message, false otherwise.
+     */
+    public static function match($output)
+    {
+        return strpos($output, 'Error response from daemon:') !== false
+            && strpos($output, 'bind: address already in use.') !== false;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new exception handling mechanism for bind address conflicts in the Docker-related classes. The most important changes include the addition of a new exception class `BindAddressAlreadyUseException` and the integration of this exception into the existing `GenericContainer` and `BaseCommand` classes.

### Exception Handling Improvements:

* [`src/Docker/Exception/BindAddressAlreadyUseException.php`](diffhunk://#diff-d9462767d19f0faa07d3b4976f338186e87c08c6e6b2191a59e181183b6d59f6R1-R25): Added a new exception class `BindAddressAlreadyUseException` to handle cases where a bind address is already in use.

### Integration of New Exception:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R1039-R1050): Updated the `start` method to catch and handle `BindAddressAlreadyUseException`, incorporating conflict behavior strategies such as retrying or failing.
* [`src/Docker/Command/BaseCommand.php`](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R256-R257): Modified the `execute` method to throw `BindAddressAlreadyUseException` when the relevant error message is detected in the output.

### Additional Imports:

* [`src/Containers/GenericContainer.php`](diffhunk://#diff-2e5f4c3047ca1e0961cd42b35e010465268c11f22d58c01c1273bb0eee9bc8a1R23): Added an import for `BindAddressAlreadyUseException`.
* [`src/Docker/Command/BaseCommand.php`](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R7): Added an import for `BindAddressAlreadyUseException`.