### PR TITLE
Refactor and enhance port exposure handling in GenericContainer

### DIFF
--- a/src/Containers/GenericContainer/ExposedPortSetting.php
+++ b/src/Containers/GenericContainer/ExposedPortSetting.php
@@ -130,11 +130,13 @@ trait ExposedPortSetting
     /**
      * Retrieve the ports to be exposed by the container.
      *
-     * This method returns the ports that should be exposed by the container.
-     * If specific ports are set, it will return those. Otherwise, it will
-     * attempt to retrieve the default ports from the provider.
+     * This method checks for ports defined in the following order:
+     * 1. Static variable `$EXPOSED_PORTS`
+     * 2. Static variable `$EXPOSE`
+     * 3. Static variable `$PORTS`
+     * 4. Instance variable `$exposedPorts`
      *
-     * @return int[]|null The ports to be exposed, or null if none are set.
+     * @return int[] The list of ports to be exposed.
      */
     protected function exposedPorts()
     {
@@ -150,6 +152,6 @@ trait ExposedPortSetting
         if ($this->exposedPorts) {
             return $this->exposedPorts;
         }
-        return null;
+        return [];
     }
 }

--- a/src/Containers/GenericContainer/ExposedPortSetting.php
+++ b/src/Containers/GenericContainer/ExposedPortSetting.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+/**
+ * ExposedPortSetting is a trait that provides the ability to expose ports on a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$PORTS`:
+ *
+ * <code>
+ * class YourContainer extends GenericContainer
+ * {
+ *     protected static $PORTS = [80, 443];
+ * }
+ * </code>
+ *
+ * 2. method `withExposedPorts`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *        ->withExposedPorts(80);
+ * </code>
+ */
+trait ExposedPortSetting
+{
+    /**
+     * Define the default ports to be exposed by the container.
+     * @var int[]|null
+     */
+    protected static $PORTS;
+
+    /**
+     * The ports to be exposed by the container.
+     * @var int[]
+     */
+    private $ports = [];
+
+    /**
+     * Set the ports that this container listens on.
+     *
+     * @param array|int|string $ports The ports to expose. Can be a single port, a range of ports, or an array of ports.
+     * @return self
+     */
+    public function withExposedPorts($ports)
+    {
+        if (is_int($ports)) {
+            $ports = [$ports];
+        }
+        if (is_string($ports)) {
+            $ports = [intval($ports)];
+        }
+        $this->ports = $ports;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the ports to be exposed by the container.
+     *
+     * This method returns the ports that should be exposed by the container.
+     * If specific ports are set, it will return those. Otherwise, it will
+     * attempt to retrieve the default ports from the provider.
+     *
+     * @return int[]|null The ports to be exposed, or null if none are set.
+     */
+    protected function ports()
+    {
+        if (static::$PORTS) {
+            return static::$PORTS;
+        }
+        if ($this->ports) {
+            return $this->ports;
+        }
+        return null;
+    }
+}

--- a/src/Containers/GenericContainer/ExposedPortSetting.php
+++ b/src/Containers/GenericContainer/ExposedPortSetting.php
@@ -6,20 +6,20 @@ namespace Testcontainers\Containers\GenericContainer;
  * ExposedPortSetting is a trait that provides the ability to expose ports on a container.
  *
  * Two formats are supported:
- * 1. static variable `$PORTS`:
+ * 1. static variable `$EXPOSED_PORTS`:
  *
  * <code>
  * class YourContainer extends GenericContainer
  * {
- *     protected static $PORTS = [80, 443];
+ *     protected static $EXPOSED_PORTS = [80, 443];
  * }
  * </code>
  *
  * 2. method `withExposedPorts`:
  *
  * <code>
- *     $container = (new YourContainer('image'))
- *        ->withExposedPorts(80);
+ * $container = (new YourContainer('image'))
+ *     ->withExposedPorts(80);
  * </code>
  */
 trait ExposedPortSetting
@@ -28,13 +28,13 @@ trait ExposedPortSetting
      * Define the default ports to be exposed by the container.
      * @var int[]|null
      */
-    protected static $PORTS;
+    protected static $EXPOSED_PORTS;
 
     /**
      * The ports to be exposed by the container.
      * @var int[]
      */
-    private $ports = [];
+    private $exposedPorts = [];
 
     /**
      * Set the ports that this container listens on.
@@ -50,7 +50,7 @@ trait ExposedPortSetting
         if (is_string($ports)) {
             $ports = [intval($ports)];
         }
-        $this->ports = $ports;
+        $this->exposedPorts = $ports;
 
         return $this;
     }
@@ -64,13 +64,13 @@ trait ExposedPortSetting
      *
      * @return int[]|null The ports to be exposed, or null if none are set.
      */
-    protected function ports()
+    protected function exposedPorts()
     {
-        if (static::$PORTS) {
-            return static::$PORTS;
+        if (static::$EXPOSED_PORTS) {
+            return static::$EXPOSED_PORTS;
         }
-        if ($this->ports) {
-            return $this->ports;
+        if ($this->exposedPorts) {
+            return $this->exposedPorts;
         }
         return null;
     }

--- a/src/Containers/GenericContainer/ExposedPortSetting.php
+++ b/src/Containers/GenericContainer/ExposedPortSetting.php
@@ -31,6 +31,18 @@ trait ExposedPortSetting
     protected static $EXPOSED_PORTS;
 
     /**
+     * Define the default ports to be exposed by the container. Alias for `EXPOSED_PORTS`.
+     * @var int[]|null
+     */
+    protected static $EXPOSE;
+
+    /**
+     * Define the default ports to be exposed by the container. Alias for `EXPOSED_PORTS`.
+     * @var int[]|null
+     */
+    protected static $PORTS;
+
+    /**
      * The ports to be exposed by the container.
      * @var int[]
      */
@@ -53,6 +65,28 @@ trait ExposedPortSetting
     }
 
     /**
+     * Set the port that this container listens on. Alias for `withExposedPort`.
+     *
+     * @param int|string $port The port to expose.
+     * @return self
+     */
+    public function withExpose($port)
+    {
+        return $this->withExposedPort($port);
+    }
+
+    /**
+     * Set the port that this container listens on. Alias for `withExposedPort`.
+     *
+     * @param int|string $port The port to expose.
+     * @return self
+     */
+    public function withPort($port)
+    {
+        return $this->withExposedPort($port);
+    }
+
+    /**
      * Set the ports that this container listens on.
      *
      * @param array|int|string $ports The ports to expose. Can be a single port, a range of ports, or an array of ports.
@@ -72,6 +106,28 @@ trait ExposedPortSetting
     }
 
     /**
+     * Set the ports that this container listens on. Alias for `withExposedPorts`.
+     *
+     * @param array|int|string $ports The ports to expose. Can be a single port, a range of ports, or an array of ports.
+     * @return self
+     */
+    public function withExposes($ports)
+    {
+        return $this->withExposedPorts($ports);
+    }
+
+    /**
+     * Set the ports that this container listens on. Alias for `withExposedPorts`.
+     *
+     * @param array|int|string $ports The ports to expose. Can be a single port, a range of ports, or an array of ports.
+     * @return self
+     */
+    public function withPorts($ports)
+    {
+        return $this->withExposedPorts($ports);
+    }
+
+    /**
      * Retrieve the ports to be exposed by the container.
      *
      * This method returns the ports that should be exposed by the container.
@@ -84,6 +140,12 @@ trait ExposedPortSetting
     {
         if (static::$EXPOSED_PORTS) {
             return static::$EXPOSED_PORTS;
+        }
+        if (static::$EXPOSE) {
+            return static::$EXPOSE;
+        }
+        if (static::$PORTS) {
+            return static::$PORTS;
         }
         if ($this->exposedPorts) {
             return $this->exposedPorts;

--- a/src/Containers/GenericContainer/ExposedPortSetting.php
+++ b/src/Containers/GenericContainer/ExposedPortSetting.php
@@ -37,6 +37,22 @@ trait ExposedPortSetting
     private $exposedPorts = [];
 
     /**
+     * Set the port that this container listens on.
+     *
+     * @param int|string $port The port to expose.
+     * @return self
+     */
+    public function withExposedPort($port)
+    {
+        if (is_string($port)) {
+            $port = intval($port);
+        }
+        $this->exposedPorts[] = $port;
+
+        return $this;
+    }
+
+    /**
      * Set the ports that this container listens on.
      *
      * @param array|int|string $ports The ports to expose. Can be a single port, a range of ports, or an array of ports.

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -34,8 +34,9 @@ use Testcontainers\Exceptions\InvalidFormatException;
  */
 class GenericContainer implements Container
 {
-    use MountSetting;
+    use ExposedPortSetting;
     use HostSetting;
+    use MountSetting;
 
     /**
      * The Docker client.
@@ -105,18 +106,6 @@ class GenericContainer implements Container
      * }[]
      */
     private $volumesFrom = [];
-
-    /**
-     * Define the default ports to be exposed by the container.
-     * @var int[]|null
-     */
-    protected static $PORTS;
-
-    /**
-     * The ports to be exposed by the container.
-     * @var int[]
-     */
-    private $ports = [];
 
     /**
      * Define the default environment variables to be used for the container.
@@ -294,22 +283,6 @@ class GenericContainer implements Container
             'name' => $container->getContainerId(),
             'mode' => $mode,
         ];
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withExposedPorts($ports)
-    {
-        if (is_int($ports)) {
-            $ports = [$ports];
-        }
-        if (is_string($ports)) {
-            $ports = [intval($ports)];
-        }
-        $this->ports = $ports;
 
         return $this;
     }
@@ -557,26 +530,6 @@ class GenericContainer implements Container
         }
 
         return empty($volumesFrom) ? null : $volumesFrom;
-    }
-
-    /**
-     * Retrieve the ports to be exposed by the container.
-     *
-     * This method returns the ports that should be exposed by the container.
-     * If specific ports are set, it will return those. Otherwise, it will
-     * attempt to retrieve the default ports from the provider.
-     *
-     * @return int[]|null The ports to be exposed, or null if none are set.
-     */
-    protected function ports()
-    {
-        if (static::$PORTS) {
-            return static::$PORTS;
-        }
-        if ($this->ports) {
-            return $this->ports;
-        }
-        return null;
     }
 
     /**

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -766,7 +766,7 @@ class GenericContainer implements Container
         }
 
         $portStrategy = $this->portStrategy();
-        $containerPorts = $this->ports();
+        $containerPorts = $this->exposedPorts();
         $ports = [];
         if ($portStrategy && $containerPorts) {
             foreach ($containerPorts as $containerPort) {

--- a/tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\ExposedPortSetting;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\PortStrategy\LocalRandomPortStrategy;
+
+class ExposedPortSettingTest extends TestCase
+{
+    public function testHasMountSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(ExposedPortSetting::class, $uses);
+    }
+
+    public function testStaticPorts()
+    {
+        $container = (new ExposedPortSettingWithPortsContainer('alpine:latest'));
+        $instance = $container->start();
+
+        $this->assertSame([80, 443], $instance->getExposedPorts());
+    }
+
+    public function testStartWithExposedPorts()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withExposedPorts(80)
+            ->withPortStrategy(new LocalRandomPortStrategy());
+        $instance = $container->start();
+
+        $this->assertSame([80], $instance->getExposedPorts());
+    }
+}
+
+class ExposedPortSettingWithPortsContainer extends GenericContainer
+{
+    protected static $PORTS = [80, 443];
+
+    protected static $PORT_STRATEGY = 'local_random';
+}

--- a/tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php
@@ -39,7 +39,7 @@ class ExposedPortSettingTest extends TestCase
 
 class ExposedPortSettingWithPortsContainer extends GenericContainer
 {
-    protected static $PORTS = [80, 443];
+    protected static $EXPOSED_PORTS = [80, 443];
 
     protected static $PORT_STRATEGY = 'local_random';
 }

--- a/tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php
@@ -18,6 +18,22 @@ class ExposedPortSettingTest extends TestCase
         $this->assertContains(ExposedPortSetting::class, $uses);
     }
 
+    public function testStaticExposedPorts()
+    {
+        $container = (new ExposedPortSettingWithExposedPortsContainer('alpine:latest'));
+        $instance = $container->start();
+
+        $this->assertSame([80, 443], $instance->getExposedPorts());
+    }
+
+    public function testStaticExpose()
+    {
+        $container = (new ExposedPortSettingWithExposeContainer('alpine:latest'));
+        $instance = $container->start();
+
+        $this->assertSame([80, 443], $instance->getExposedPorts());
+    }
+
     public function testStaticPorts()
     {
         $container = (new ExposedPortSettingWithPortsContainer('alpine:latest'));
@@ -26,10 +42,60 @@ class ExposedPortSettingTest extends TestCase
         $this->assertSame([80, 443], $instance->getExposedPorts());
     }
 
+    public function testStartWithExposedPort()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withExposedPort(80)
+            ->withPortStrategy(new LocalRandomPortStrategy());
+        $instance = $container->start();
+
+        $this->assertSame([80], $instance->getExposedPorts());
+    }
+
+    public function testStartWithExpose()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withExpose(80)
+            ->withPortStrategy(new LocalRandomPortStrategy());
+        $instance = $container->start();
+
+        $this->assertSame([80], $instance->getExposedPorts());
+    }
+
+    public function testStartWithPort()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withPort(80)
+            ->withPortStrategy(new LocalRandomPortStrategy());
+        $instance = $container->start();
+
+        $this->assertSame([80], $instance->getExposedPorts());
+    }
+
     public function testStartWithExposedPorts()
     {
         $container = (new GenericContainer('alpine:latest'))
-            ->withExposedPorts(80)
+            ->withExposedPorts([80])
+            ->withPortStrategy(new LocalRandomPortStrategy());
+        $instance = $container->start();
+
+        $this->assertSame([80], $instance->getExposedPorts());
+    }
+
+    public function testStartWithExposes()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withExposes([80])
+            ->withPortStrategy(new LocalRandomPortStrategy());
+        $instance = $container->start();
+
+        $this->assertSame([80], $instance->getExposedPorts());
+    }
+
+    public function testStartWithPorts()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withPorts([80])
             ->withPortStrategy(new LocalRandomPortStrategy());
         $instance = $container->start();
 
@@ -37,9 +103,24 @@ class ExposedPortSettingTest extends TestCase
     }
 }
 
-class ExposedPortSettingWithPortsContainer extends GenericContainer
+class ExposedPortSettingWithExposedPortsContainer extends GenericContainer
 {
     protected static $EXPOSED_PORTS = [80, 443];
+
+    // TODO: implements default port strategy
+    protected static $PORT_STRATEGY = 'local_random';
+}
+
+class ExposedPortSettingWithExposeContainer extends GenericContainer
+{
+    protected static $EXPOSE = [80, 443];
+
+    protected static $PORT_STRATEGY = 'local_random';
+}
+
+class ExposedPortSettingWithPortsContainer extends GenericContainer
+{
+    protected static $PORTS = [80, 443];
 
     protected static $PORT_STRATEGY = 'local_random';
 }


### PR DESCRIPTION
This pull request introduces a new trait `ExposedPortSetting` to handle port exposure for containers in the `GenericContainer` class and updates the relevant tests. The most important changes include the addition of the new trait, refactoring the `GenericContainer` class to use this trait, and adding comprehensive tests to ensure functionality.

### New Feature Addition:
* [`src/Containers/GenericContainer/ExposedPortSetting.php`](diffhunk://#diff-558ee67324849e6d1381aeebdfbd1ef92e8fe5ff96e8d384f207df393ee54cf3R1-R157): Introduced the `ExposedPortSetting` trait to manage port exposure with methods for setting and retrieving exposed ports.

### Refactoring:
* `src/Containers/GenericContainer/GenericContainer.php`: 
  * Added the `ExposedPortSetting` trait to the `GenericContainer` class.
  * Removed redundant port-related properties and methods, as these are now handled by the `ExposedPortSetting` trait. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L109-L120) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L301-L316) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L562-L581) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L816-R769)

### Testing:
* [`tests/Unit/Containers/GenericContainer/ExposedPortSettingTest.php`](diffhunk://#diff-ce0e8f9a40396b1cc1707f7c37c183b4bf21db0d219a9154dc2afbf005dc0296R1-R126): Added unit tests for the `ExposedPortSetting` trait to verify different methods of setting and retrieving exposed ports.