### PR TITLE
Refactor and enhance network mode handling for containers

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -38,6 +38,7 @@ class GenericContainer implements Container
     use ExposedPortSetting;
     use HostSetting;
     use MountSetting;
+    use NetworkModeSetting;
 
     /**
      * The Docker client.
@@ -68,18 +69,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default network mode to be used for the container.
-     * @var string|null
-     */
-    protected static $NETWORK_MODE;
-
-    /**
-     * The network mode to be used for the container.
-     * @var string|null
-     */
-    private $networkMode;
 
     /**
      * Define the default network aliases to be used for the container.
@@ -319,16 +308,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withNetworkMode($networkMode)
-    {
-        $this->networkMode = $networkMode;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withNetworkAliases($aliases)
     {
         $this->networkAliases = $aliases;
@@ -422,22 +401,6 @@ class GenericContainer implements Container
         }
         if ($this->commands) {
             return $this->commands;
-        }
-        return null;
-    }
-
-    /**
-     * Retrieve the network mode to be used for the container.
-     *
-     * @return string|null
-     */
-    protected function networkMode()
-    {
-        if (static::$NETWORK_MODE) {
-            return static::$NETWORK_MODE;
-        }
-        if ($this->networkMode) {
-            return $this->networkMode;
         }
         return null;
     }

--- a/src/Containers/GenericContainer/NetworkModeSetting.php
+++ b/src/Containers/GenericContainer/NetworkModeSetting.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+use Testcontainers\Containers\Types\NetworkMode;
+
+trait NetworkModeSetting
+{
+    /**
+     * Define the default network mode to be used for the container.
+     * @var string|null
+     */
+    protected static $NETWORK_MODE;
+
+    /**
+     * The network mode to be used for the container.
+     * @var NetworkMode|null
+     */
+    private $networkMode;
+
+    /**
+     * Set the network mode for this container, similar to the `--net <name>` option on the Docker CLI.
+     *
+     * @param NetworkMode $networkMode The network mode, e.g., 'host', 'bridge', 'none', or the name of an existing named network.
+     * @return self
+     */
+    public function withNetworkMode($networkMode)
+    {
+        $this->networkMode = $networkMode;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the network mode to be used for the container.
+     *
+     * @return NetworkMode|null
+     */
+    protected function networkMode()
+    {
+        if (static::$NETWORK_MODE) {
+            return NetworkMode::fromString(static::$NETWORK_MODE);
+        }
+        if ($this->networkMode) {
+            return $this->networkMode;
+        }
+        return null;
+    }
+}

--- a/src/Containers/Types/NetworkMode.php
+++ b/src/Containers/Types/NetworkMode.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Testcontainers\Containers\Types;
+
+/**
+ * Represents a network mode for a container.
+ *
+ * This class encapsulates the network name or driver used by a container and provides
+ * convenient access to common network modes (`host`, `bridge`), as well as supporting
+ * custom network modes.
+ */
+class NetworkMode
+{
+    /**
+     * Host network mode.
+     *
+     * In this mode, the container shares the host's network stack,
+     * and the container's ports will be exposed on the host's IP address.
+     * No port mapping is required.
+     *
+     * @var string
+     */
+    public static $HOST = 'host';
+
+    /**
+     * Bridge network mode (default).
+     *
+     * The container has its own network stack, isolated from the host.
+     * Port mapping is typically used to expose container ports to the host.
+     *
+     * @var string
+     */
+    public static $BRIDGE = 'bridge';
+
+    /**
+     * None network mode.
+     *
+     * In this mode, the container has no network access.
+     *
+     * @var string
+     */
+    public static $NONE = 'none';
+
+    /**
+     * The network mode.
+     * The name of the network or driver used by the container.
+     *
+     * @var string
+     */
+    private $mode;
+
+    /**
+     * Initializes a NetworkMode object.
+     *
+     * @param string $mode The network mode (e.g., 'host', 'bridge', or a custom network name).
+     */
+    public function __construct($mode)
+    {
+        $this->mode = $mode;
+    }
+
+    /**
+     * Creates a NetworkMode object with the host network mode.
+     *
+     * @return self A NetworkMode object with the host network mode.
+     */
+    public static function HOST()
+    {
+        return new self(self::$HOST);
+    }
+
+    /**
+     * Creates a NetworkMode object with the bridge network mode.
+     *
+     * @return self A NetworkMode object with the bridge network mode.
+     */
+    public static function BRIDGE()
+    {
+        return new self(self::$BRIDGE);
+    }
+
+    /**
+     * Creates a NetworkMode object with the none network mode.
+     *
+     * @return self A NetworkMode object with the none network mode.
+     */
+    public static function NONE()
+    {
+        return new self(self::$NONE);
+    }
+
+    /**
+     * Creates a NetworkMode object from a string.
+     *
+     * @param string $s The network mode string.
+     * @return NetworkMode A NetworkMode object representing the given network mode.
+     */
+    public static function fromString($s)
+    {
+        return new self($s);
+    }
+
+    /**
+     * Returns the network mode as a string.
+     *
+     * @return string The network mode.
+     */
+    public function toString()
+    {
+        return $this->mode;
+    }
+
+    /**
+     * Returns the network mode as a string (alias for toString()).
+     *
+     * @return string The network mode.
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -291,6 +291,11 @@ trait BaseCommand
                 $result[] = $this->expandEnv($value);
                 continue;
             }
+            if (method_exists($value, '__toString')) {
+                $result[] = "--$key";
+                $result[] = (string) $value;
+                continue;
+            }
             if (is_array($value)) {
                 foreach ($value as $k => $v) {
                     $result[] = "--$key";

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -291,7 +291,7 @@ trait BaseCommand
                 $result[] = $this->expandEnv($value);
                 continue;
             }
-            if (method_exists($value, '__toString')) {
+            if (is_object($value) && method_exists($value, '__toString')) {
                 $result[] = "--$key";
                 $result[] = (string) $value;
                 continue;
@@ -303,7 +303,7 @@ trait BaseCommand
                         $result[] = $k . '=' . $this->expandEnv($v);
                     } elseif (is_scalar($v) && !is_bool($v)) {
                         $result[] = $this->expandEnv($v);
-                    } elseif (method_exists($v, '__toString')) {
+                    } elseif (is_object($v) && method_exists($v, '__toString')) {
                         $result[] = $this->expandEnv((string) $v);
                     } else {
                         throw new LogicException('Unsupported value type: `' . var_export($v, true) . '`');

--- a/tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\NetworkModeSetting;
+use Testcontainers\Containers\Types\NetworkMode;
+
+class NetworkModeSettingTest extends TestCase
+{
+    public function testHasNetworkModeSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(NetworkModeSetting::class, $uses);
+    }
+
+    public function testStaticNetworkMode()
+    {
+        $container = (new NetworkModeSettingWithStaticNetworkModeContainer('alpine:latest'))
+            ->withCommands(['sh', '-c', 'ls /sys/class/net']);
+        $instance = $container->start();
+
+        $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
+    }
+
+    public function testStartWithNetworkMode()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withNetworkMode(NetworkMode::NONE())
+            ->withCommands(['sh', '-c', 'ls /sys/class/net']);
+        $instance = $container->start();
+
+        $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
+    }
+
+//    public function testStartWithNetworkMode()
+//    {
+//        $container = (new GenericContainer('alpine:latest'))
+//            ->withNetworkMode('none')
+//            ->withCommands(['sh', '-c', 'ls /sys/class/net']);
+//        /** @noinspection PhpUnhandledExceptionInspection */
+//        $instance = $container->start();
+//
+//        $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
+//    }
+}
+
+class NetworkModeSettingWithStaticNetworkModeContainer extends GenericContainer
+{
+    protected static $NETWORK_MODE = 'none';
+}

--- a/tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php
@@ -36,17 +36,6 @@ class NetworkModeSettingTest extends TestCase
 
         $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
     }
-
-//    public function testStartWithNetworkMode()
-//    {
-//        $container = (new GenericContainer('alpine:latest'))
-//            ->withNetworkMode('none')
-//            ->withCommands(['sh', '-c', 'ls /sys/class/net']);
-//        /** @noinspection PhpUnhandledExceptionInspection */
-//        $instance = $container->start();
-//
-//        $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
-//    }
 }
 
 class NetworkModeSettingWithStaticNetworkModeContainer extends GenericContainer

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -69,17 +69,6 @@ class GenericContainerTest extends TestCase
         $this->assertSame("Hello, World!\n", $instance->getOutput());
     }
 
-    public function testStartWithNetworkMode()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withNetworkMode('none')
-            ->withCommands(['sh', '-c', 'ls /sys/class/net']);
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertFalse(strpos($instance->getOutput(), 'eth0'));
-    }
-
     public function testStartWithNetworkAliases()
     {
         $instance = Testcontainers::run(DinD::class);

--- a/tests/Unit/Containers/Types/NetworkModeTest.php
+++ b/tests/Unit/Containers/Types/NetworkModeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Containers\Types;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\Types\NetworkMode;
+
+class NetworkModeTest extends TestCase
+{
+    public function testNetworkModeHost()
+    {
+        $mode = new NetworkMode(NetworkMode::$HOST);
+
+        $this->assertSame(NetworkMode::$HOST, $mode->toString());
+    }
+
+    public function testNetworkModeBridge()
+    {
+        $mode = new NetworkMode(NetworkMode::$BRIDGE);
+
+        $this->assertSame(NetworkMode::$BRIDGE, $mode->toString());
+    }
+
+    public function testNetworkModeNone()
+    {
+        $mode = new NetworkMode(NetworkMode::$NONE);
+
+        $this->assertSame(NetworkMode::$NONE, $mode->toString());
+    }
+
+    public function testNetworkModeCustom()
+    {
+        $mode = new NetworkMode('custom');
+
+        $this->assertSame('custom', $mode->toString());
+    }
+
+    public function testHost()
+    {
+        $mode = NetworkMode::HOST();
+
+        $this->assertSame(NetworkMode::$HOST, $mode->toString());
+    }
+
+    public function testBridge()
+    {
+        $mode = NetworkMode::BRIDGE();
+
+        $this->assertSame(NetworkMode::$BRIDGE, $mode->toString());
+    }
+
+    public function testNone()
+    {
+        $mode = NetworkMode::NONE();
+
+        $this->assertSame(NetworkMode::$NONE, $mode->toString());
+    }
+
+    public function testFromStringWithHost()
+    {
+        $mode = NetworkMode::fromString(NetworkMode::$HOST);
+
+        $this->assertSame(NetworkMode::$HOST, $mode->toString());
+    }
+
+    public function testFromStringWithBridge()
+    {
+        $mode = NetworkMode::fromString(NetworkMode::$BRIDGE);
+
+        $this->assertSame(NetworkMode::$BRIDGE, $mode->toString());
+    }
+
+    public function testFromStringWithNone()
+    {
+        $mode = NetworkMode::fromString(NetworkMode::$NONE);
+
+        $this->assertSame(NetworkMode::$NONE, $mode->toString());
+    }
+
+    public function testFromStringWithCustom()
+    {
+        $mode = NetworkMode::fromString('custom');
+
+        $this->assertSame('custom', $mode->toString());
+    }
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `GenericContainer` class to refactor how network modes are handled, including the addition of a new `NetworkModeSetting` trait and a `NetworkMode` class. The key changes involve moving network mode functionality to a separate trait, updating related methods, and adding comprehensive tests.

Refactoring network mode handling:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R41): Added the `NetworkModeSetting` trait and removed the `networkMode` property and related methods from the `GenericContainer` class. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R41) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L72-L83) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L319-L328) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L429-L444)
* [`src/Containers/GenericContainer/NetworkModeSetting.php`](diffhunk://#diff-a65b8a09317cdcca8660fd98bc9aedf1bd83ed6cadde92e7d76b2537ded2a4d4R1-R49): Introduced the `NetworkModeSetting` trait to encapsulate network mode functionality, including setting and retrieving the network mode.
* [`src/Containers/Types/NetworkMode.php`](diffhunk://#diff-caf9daf2eb741104083cec4acd44057ec6451d9c885b178d0353fbfc2730a6c3R1-R122): Added the `NetworkMode` class to represent different network modes and provide utility methods for common network modes (`host`, `bridge`, `none`).
* [`src/Docker/Command/BaseCommand.php`](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R294-R298): Updated the `arrayToArgs` method to handle objects that can be converted to strings, such as instances of `NetworkMode`.

Adding tests:

* [`tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php`](diffhunk://#diff-736e06f195d703a3f0a1d39d84bcbaf94f51af17b5f74def39616a5a0c674081R1-R55): Added unit tests for the `NetworkModeSetting` trait to verify its functionality.
* [`tests/Unit/Containers/Types/NetworkModeTest.php`](diffhunk://#diff-b0ae7a9483aa3d35d9496c6f803fbedeb3ee8cc166b61c9fb18fd5d9a799e97cR1-R86): Added unit tests for the `NetworkMode` class to ensure correct behavior of network mode conversions and utility methods.