### PR TITLE
Refactor and enhance network alias management with NetworkAliasSetting trait

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -38,6 +38,7 @@ class GenericContainer implements Container
     use ExposedPortSetting;
     use HostSetting;
     use MountSetting;
+    use NetworkAliasSetting;
     use NetworkModeSetting;
 
     /**
@@ -69,18 +70,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default network aliases to be used for the container.
-     * @var string[]|null
-     */
-    protected static $NETWORK_ALIASES;
-
-    /**
-     * The network aliases to be used for the container.
-     * @var string[]
-     */
-    private $networkAliases = [];
 
     /**
      * Define the default volumes to be used for the container.
@@ -308,16 +297,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withNetworkAliases($aliases)
-    {
-        $this->networkAliases = $aliases;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withImagePullPolicy($policy)
     {
         $this->pullPolicy = $policy;
@@ -403,22 +382,6 @@ class GenericContainer implements Container
             return $this->commands;
         }
         return null;
-    }
-
-    /**
-     * Retrieve the network aliases to be used for the container.
-     *
-     * @return string[]
-     */
-    protected function networkAliases()
-    {
-        if (static::$NETWORK_ALIASES) {
-            return static::$NETWORK_ALIASES;
-        }
-        if ($this->networkAliases) {
-            return $this->networkAliases;
-        }
-        return [];
     }
 
     /**

--- a/src/Containers/GenericContainer/NetworkAliasSetting.php
+++ b/src/Containers/GenericContainer/NetworkAliasSetting.php
@@ -37,6 +37,19 @@ trait NetworkAliasSetting
     private $networkAliases = [];
 
     /**
+     * Set the network alias for this container, similar to the `--network-alias <my-service>` option on the Docker CLI.
+     *
+     * @param string $alias The network alias to set.
+     * @return self
+     */
+    public function withNetworkAlias($alias)
+    {
+        $this->networkAliases[] = $alias;
+
+        return $this;
+    }
+
+    /**
      * Set the network aliases for this container, similar to the `--network-alias <my-service>` option on the Docker CLI.
      *
      * @param string[] $aliases The network aliases to set.

--- a/src/Containers/GenericContainer/NetworkAliasSetting.php
+++ b/src/Containers/GenericContainer/NetworkAliasSetting.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+/**
+ * NetworkAliasSetting is a trait that provides the ability to add network aliases to a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$NETWORK_ALIASES`:
+ *
+ * <code>
+ *     class YourContainer extends GenericContainer
+ *     {
+ *         protected static $NETWORK_ALIASES = ['my-service'];
+ *     }
+ * </code>
+ *
+ * 2. method `withNetworkAliases`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *         ->withNetworkAliases(['my-service']);
+ * </code>
+ */
+trait NetworkAliasSetting
+{
+    /**
+     * Define the default network aliases to be used for the container.
+     * @var string[]|null
+     */
+    protected static $NETWORK_ALIASES;
+
+    /**
+     * The network aliases to be used for the container.
+     * @var string[]
+     */
+    private $networkAliases = [];
+
+    /**
+     * Set the network aliases for this container, similar to the `--network-alias <my-service>` option on the Docker CLI.
+     *
+     * @param string[] $aliases The network aliases to set.
+     * @return self
+     */
+    public function withNetworkAliases($aliases)
+    {
+        $this->networkAliases = $aliases;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the network aliases to be used for the container.
+     *
+     * @return string[]
+     */
+    protected function networkAliases()
+    {
+        if (static::$NETWORK_ALIASES) {
+            return static::$NETWORK_ALIASES;
+        }
+        if ($this->networkAliases) {
+            return $this->networkAliases;
+        }
+        return [];
+    }
+}

--- a/tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\NetworkAliasSetting;
+use Testcontainers\Containers\Types\NetworkMode;
+use Testcontainers\Docker\DockerClientFactory;
+use Testcontainers\Testcontainers;
+use Tests\Images\DinD;
+
+class NetworkAliasSettingTest extends TestCase
+{
+    public function testHasNetworkAliasSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(NetworkAliasSetting::class, $uses);
+    }
+
+    public function testStaticNetworkAlias()
+    {
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = DockerClientFactory::create([
+            'globalOptions' => [
+                'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375)
+            ],
+        ]);
+        $network =NetworkMode::fromString(md5(uniqid()));
+        $client->networkCreate($network);
+
+        $container = (new NetworkAliasSettingWithStaticNetworkAliasContainer('alpine:latest'))
+            ->withDockerClient($client)
+            ->withNetworkMode($network)
+            ->withCommands(['sh', '-c', 'ping -c 1 my-service']);
+        $instance = $container->start();
+
+        $this->assertStringStartsWith('PING my-service', $instance->getOutput());
+    }
+
+    public function testStartWithNetworkAliases()
+    {
+        $instance = Testcontainers::run(DinD::class);
+
+        $client = DockerClientFactory::create([
+            'globalOptions' => [
+                'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375)
+            ],
+        ]);
+        $network = NetworkMode::fromString(md5(uniqid()));
+        $client->networkCreate($network);
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withDockerClient($client)
+            ->withNetworkMode($network)
+            ->withNetworkAliases(['my-alias'])
+            ->withCommands(['sh', '-c', 'ping -c 1 my-alias']);
+        $instance = $container->start();
+
+        $this->assertStringStartsWith('PING my-alias', $instance->getOutput());
+    }
+}
+
+class NetworkAliasSettingWithStaticNetworkAliasContainer extends GenericContainer
+{
+    protected static $NETWORK_ALIASES = ['my-service'];
+}

--- a/tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php
@@ -30,7 +30,7 @@ class NetworkAliasSettingTest extends TestCase
                 'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375)
             ],
         ]);
-        $network =NetworkMode::fromString(md5(uniqid()));
+        $network = NetworkMode::fromString(md5(uniqid()));
         $client->networkCreate($network);
 
         $container = (new NetworkAliasSettingWithStaticNetworkAliasContainer('alpine:latest'))


### PR DESCRIPTION
This pull request introduces the `NetworkAliasSetting` trait to the `GenericContainer` class, simplifying the management of network aliases for containers. The most significant changes involve the removal of direct network alias handling from the `GenericContainer` class and the addition of a new trait to encapsulate this functionality. Additionally, tests have been added to ensure the new trait works as expected.

Improvements to network alias management:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R41): Added the `NetworkAliasSetting` trait to the `GenericContainer` class and removed the direct handling of network aliases. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R41) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L73-L84) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L308-L317) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L408-L423)
* [`src/Containers/GenericContainer/NetworkAliasSetting.php`](diffhunk://#diff-106e1b67cf3f7cdb1591ac06a547edd5f13f46317347f2293a891fb070704200R1-R80): Introduced the `NetworkAliasSetting` trait to manage network aliases, including methods for setting and retrieving aliases.

Testing:

* [`tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php`](diffhunk://#diff-fc405504e6ec9985f45033d106f4181d527ecb209d865e4dd78a0220d55d7843R1-R93): Added unit tests to verify the functionality of the `NetworkAliasSetting` trait, including tests for static network aliases and dynamic alias configurations.