### PR TITLE
Refactor container naming and volume management with new traits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "composer dump-autoload"
         ],
         "format": "php-cs-fixer fix .",
-        "lint:php-cs-fixer": "php-cs-fixer fix --diff --dry-run .",
+        "lint:php-cs-fixer": "php-cs-fixer fix --dry-run .",
         "lint": [
             "@lint:php-cs-fixer"
         ],

--- a/src/Containers/Container.php
+++ b/src/Containers/Container.php
@@ -13,6 +13,14 @@ use Testcontainers\Containers\WaitStrategy\WaitStrategy;
 interface Container
 {
     /**
+     * Set the name for this container, similar to the `--name <name>` option on the Docker CLI.
+     *
+     * @param string $name The name to set.
+     * @return self
+     */
+    public function withName($name);
+
+    /**
      * Adds a file system binding to the container.
      *
      * @param string $hostPath The path on the host machine.

--- a/src/Containers/GenericContainer/GeneralSetting.php
+++ b/src/Containers/GenericContainer/GeneralSetting.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+/**
+ * GeneralSetting is a trait that provides the ability to set the name for a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$NAME`:
+ *
+ * <code>
+ * class YourContainer extends GenericContainer
+ * {
+ *     protected static $NAME = 'your-container';
+ * }
+ * </code>
+ *
+ * 2. method `withName`:
+ *
+ * <code>
+ * $container = (new YourContainer('image'))
+ *     ->withName('your-container');
+ * </code>
+ */
+trait GeneralSetting
+{
+    /**
+     * Define the default name to be used for the container.
+     * @var string|null
+     */
+    protected static $NAME;
+
+    /**
+     * The name to be used for the container.
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * Set the name for this container, similar to the `--name <name>` option on the Docker CLI.
+     *
+     * @param string $name The name to set.
+     * @return self
+     */
+    public function withName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the name to be used for the container.
+     *
+     * @return string|null
+     */
+    protected function name()
+    {
+        if (static::$NAME) {
+            return static::$NAME;
+        }
+        if ($this->name) {
+            return $this->name;
+        }
+        return null;
+    }
+}

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -36,10 +36,12 @@ class GenericContainer implements Container
 {
     use EnvSetting;
     use ExposedPortSetting;
+    use GeneralSetting;
     use HostSetting;
     use MountSetting;
     use NetworkAliasSetting;
     use NetworkModeSetting;
+    use VolumesFromSetting;
 
     /**
      * The Docker client.
@@ -70,21 +72,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default volumes to be used for the container.
-     * @var string[]|null
-     */
-    protected static $VOLUMES_FROM;
-
-    /**
-     * The volumes to be used for the container.
-     * @var array{
-     *    name: string,
-     *    mode: BindMode,
-     * }[]
-     */
-    private $volumesFrom = [];
 
     /**
      * Define the default labels to be used for the container.
@@ -244,19 +231,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withVolumesFrom($container, $mode)
-    {
-        $this->volumesFrom[] = [
-            'name' => $container->getContainerId(),
-            'mode' => $mode,
-        ];
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withLabel($key, $value)
     {
         $this->labels[$key] = $value;
@@ -382,49 +356,6 @@ class GenericContainer implements Container
             return $this->commands;
         }
         return null;
-    }
-
-    /**
-     * Retrieve the volumes to be used for the container.
-     *
-     * This method returns an array of volumes, where each volume is an associative array
-     * containing the container name and bind mode.
-     *
-     * @return array{
-     *     name: string,
-     *     mode: BindMode,
-     * }[] The volumes to be used for the container.
-     *
-     * @throws InvalidFormatException If the volume format is invalid.
-     */
-    protected function volumesFrom()
-    {
-        $targets = static::$VOLUMES_FROM;
-        if ($targets === null) {
-            $targets = $this->volumesFrom;
-        }
-
-        $volumesFrom = [];
-        foreach ($targets as $volume) {
-            if (is_string($volume)) {
-                $parts = explode(':', $volume);
-                $volume = [
-                    'name' => $parts[0],
-                    'mode' => isset($parts[1]) ? BindMode::fromString($parts[1]) : BindMode::READ_WRITE(),
-                ];
-            }
-
-            if (!isset($volume['name'])) {
-                throw new LogicException('Missing container name in volumes from');
-            }
-            if (!isset($volume['mode'])) {
-                throw new LogicException('Missing bind mode in volumes from');
-            }
-
-            $volumesFrom[] = $volume;
-        }
-
-        return empty($volumesFrom) ? null : $volumesFrom;
     }
 
     /**
@@ -666,6 +597,7 @@ class GenericContainer implements Container
                 'pull' => $this->pullPolicy(),
                 'workdir' => $this->workDir(),
                 'privileged' => $this->privileged(),
+                'name' => $this->name(),
             ];
             $timeout = $this->startupTimeout();
             if ($timeout !== null) {
@@ -709,6 +641,7 @@ class GenericContainer implements Container
             'image' => $this->image,
             'command' => $command,
             'args' => $args,
+            'name' => $this->name(),
             'hosts' => $hosts,
             'env' => $this->env(),
             'labels' => $this->labels(),

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -559,18 +559,6 @@ class GenericContainer implements Container
             }
         }
 
-        $containerVolumes = $this->volumesFrom();
-        $volumesFrom = [];
-        if ($containerVolumes) {
-            foreach ($containerVolumes as $volume) {
-                $s = $volume['name'];
-                if ($volume['mode'] === BindMode::READ_ONLY()) {
-                    $s .= ':ro';
-                }
-                $volumesFrom[] = $s;
-            }
-        }
-
         $portStrategy = $this->portStrategy();
         $containerPorts = $this->exposedPorts();
         $ports = [];
@@ -592,7 +580,7 @@ class GenericContainer implements Container
                 'mount' => $this->mounts(),
                 'network' => $this->networkMode(),
                 'networkAlias' => $this->networkAliases(),
-                'volumesFrom' => $volumesFrom,
+                'volumesFrom' => $this->volumesFrom(),
                 'publish' => $ports,
                 'pull' => $this->pullPolicy(),
                 'workdir' => $this->workDir(),
@@ -648,7 +636,7 @@ class GenericContainer implements Container
             'mounts' => $this->mounts(),
             'networkMode' => $this->networkMode(),
             'networkAliases' => $this->networkAliases(),
-            'volumesFrom' => $volumesFrom,
+            'volumesFrom' => $this->volumesFrom(),
             'ports' => array_reduce($ports, function ($carry, $item) {
                 $parts = explode(':', $item);
                 $carry[(int)$parts[1]] = (int)$parts[0];

--- a/src/Containers/GenericContainer/VolumesFromSetting.php
+++ b/src/Containers/GenericContainer/VolumesFromSetting.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+use InvalidArgumentException;
+use Testcontainers\Containers\BindMode;
+use Testcontainers\Containers\ContainerInstance;
+use Testcontainers\Exceptions\InvalidFormatException;
+
+/**
+ * VolumesFromSetting is a trait that provides the ability to add volumes from other containers to a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$VOLUMES_FROM`:
+ *
+ * <code>
+ * class YourContainer extends GenericContainer
+ * {
+ *     protected static $VOLUMES_FROM = [
+ *         'container1',
+ *         'container2:ro',
+ *     ];
+ * }
+ * </code>
+ *
+ * 2. method `withVolumesFrom`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *        ->withVolumesFrom($container1, BindMode::READ_ONLY);
+ * </code>
+ */
+trait VolumesFromSetting
+{
+    /**
+     * Define the default volumes to be used for the container.
+     * @var string[]|null
+     */
+    protected static $VOLUMES_FROM;
+
+    /**
+     * The volumes to be used for the container.
+     * @var array{
+     *    name: string,
+     *    mode: BindMode,
+     * }[]
+     */
+    private $volumesFrom = [];
+
+    /**
+     * Adds container volumes to the current container instance.
+     *
+     * @param ContainerInstance $container The container instance from which to add volumes.
+     * @param BindMode $mode The mode of the bind (e.g., read-only or read-write).
+     * @return self
+     */
+    public function withVolumesFrom($container, $mode)
+    {
+        $this->volumesFrom[] = [
+            'name' => $container->getContainerId(),
+            'mode' => $mode,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the volumes to be used for the container.
+     *
+     * This method returns an array of volumes, where each volume is an associative array
+     * containing the container name and bind mode.
+     *
+     * @return array{
+     *     name: string,
+     *     mode: BindMode,
+     * }[] The volumes to be used for the container.
+     *
+     * @throws InvalidFormatException If the volume format is invalid.
+     */
+    protected function volumesFrom()
+    {
+        $targets = static::$VOLUMES_FROM;
+        if ($targets === null) {
+            $targets = $this->volumesFrom;
+        }
+
+        $volumesFrom = [];
+        foreach ($targets as $volume) {
+            if (is_string($volume)) {
+                $parts = explode(':', $volume);
+                $volume = [
+                    'name' => $parts[0],
+                    'mode' => isset($parts[1]) ? BindMode::fromString($parts[1]) : BindMode::READ_WRITE(),
+                ];
+            }
+
+            if (!isset($volume['name'])) {
+                throw new InvalidArgumentException('Missing container name in volumes from');
+            }
+            if (!isset($volume['mode'])) {
+                throw new InvalidArgumentException('Missing bind mode in volumes from');
+            }
+
+            $volumesFrom[] = $volume;
+        }
+
+        return empty($volumesFrom) ? null : $volumesFrom;
+    }
+}

--- a/src/Containers/GenericContainer/VolumesFromSetting.php
+++ b/src/Containers/GenericContainer/VolumesFromSetting.php
@@ -86,7 +86,7 @@ trait VolumesFromSetting
                     }
                     $volumesFrom[] = VolumeFrom::fromArray($volume);
                 } else {
-                    throw new InvalidArgumentException('Invalid volume from provided. Expected a string or array.');
+                    throw new InvalidFormatException($volume, 'string|array{name: string, mode?: string}');
                 }
             }
             return $volumesFrom;

--- a/src/Containers/Types/VolumeFrom.php
+++ b/src/Containers/Types/VolumeFrom.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Testcontainers\Containers\Types;
+
+use LogicException;
+use Testcontainers\Containers\BindMode;
+use Testcontainers\Exceptions\InvalidFormatException;
+
+/**
+ * Represents a volume from.
+ *
+ * @property-read string $name The name of the container to mount volumes from.
+ * @property-read BindMode $mode The mode of the bind (e.g., read-only or read-write).
+ */
+class VolumeFrom
+{
+    /**
+     * The name of the container to mount volumes from.
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The mode of the bind (e.g., read-only or read-write).
+     * @var BindMode
+     */
+    private $mode;
+
+    /**
+     * @param string $name
+     * @param BindMode $mode
+     */
+    public function __construct($name, $mode)
+    {
+        assert(is_string($name));
+        assert($mode instanceof BindMode);
+
+        $this->name = $name;
+        $this->mode = $mode;
+    }
+
+    /**
+     * Get the name of the container to mount volumes from.
+     *
+     * @param string $v The volume from string.
+     * @return VolumeFrom
+     *
+     * @throws InvalidFormatException If the mount format is invalid.
+     */
+    public static function fromString($v)
+    {
+        if (strpos($v, ':') === false) {
+            return new VolumeFrom($v, BindMode::READ_WRITE());
+        } else {
+            $parts = explode(':', $v);
+            return new VolumeFrom($parts[0], BindMode::fromString($parts[1]));
+        }
+    }
+
+    /**
+     * @param array{
+     *    name: string,
+     *    mode: BindMode
+     * } $arr The array representation of the volume from.
+     * @return VolumeFrom
+     */
+    public static function fromArray($arr)
+    {
+        return new VolumeFrom($arr['name'], $arr['mode']);
+    }
+
+    /**
+     * Get the volume from string.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return (string) $this;
+    }
+
+    public function __toString()
+    {
+        return $this->name . ':' . $this->mode->toString();
+    }
+
+    public function __get($name)
+    {
+        if (!property_exists($this, $name)) {
+            throw new LogicException('VolumeFrom::' . $name . ' does not exist');
+        }
+        return $this->$name;
+    }
+}

--- a/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\BindMode;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\VolumesFromSetting;
+use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
+use Testcontainers\Docker\DockerClientFactory;
+use Testcontainers\Testcontainers;
+use Tests\Images\DinD;
+
+class VolumesFromSettingTest extends TestCase
+{
+    public function testHasNetworkModeSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(VolumesFromSetting::class, $uses);
+    }
+
+    public function testStaticVolumesFrom()
+    {
+        $fp = tmpfile();
+        fwrite($fp, 'Hello, World!');
+        $meta = stream_get_meta_data($fp);
+        $path = $meta['uri'];
+
+        $instance = Testcontainers::run(
+            (new DinD())
+                ->withFileSystemBind(dirname($path), dirname($path), BindMode::READ_WRITE())
+        );
+        $client = DockerClientFactory::create([
+            'globalOptions' => [
+                'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375)
+            ],
+        ]);
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withDockerClient($client)
+            ->withName('volumes-from-container')
+            ->withFileSystemBind($path, $path, BindMode::READ_WRITE());
+        $instance1 = $container->start();
+
+        $container = (new VolumesFromSettingWithStaticVolumesFromContainer('alpine:latest'))
+            ->withDockerClient($client)
+            ->withCommands(['cat', $path])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
+        $instance2 = $container->start();
+
+        $this->assertSame('', $instance2->getErrorOutput());
+        $this->assertSame("Hello, World!", $instance2->getOutput());
+    }
+
+    public function testStartWithVolumesFrom()
+    {
+        $fp = tmpfile();
+        fwrite($fp, 'Hello, World!');
+        $meta = stream_get_meta_data($fp);
+        $path = $meta['uri'];
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withFileSystemBind($path, '/tmp/test', BindMode::READ_WRITE());
+        $instance1 = $container->start();
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withVolumesFrom($instance1, BindMode::READ_ONLY())
+            ->withCommands(['cat', '/tmp/test'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
+        $instance2 = $container->start();
+
+        $this->assertSame("Hello, World!", $instance2->getOutput());
+    }
+}
+
+class VolumesFromSettingWithStaticVolumesFromContainer extends GenericContainer
+{
+    protected static $VOLUMES_FROM = [
+        ['name' => 'volumes-from-container', 'mode' => 'rw'],
+    ];
+}

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -26,28 +26,6 @@ class GenericContainerTest extends TestCase
         $this->assertNotEmpty($instance->getContainerId());
     }
 
-    public function testStartWithVolumesFrom()
-    {
-        $fp = tmpfile();
-        fwrite($fp, 'Hello, World!');
-        $meta = stream_get_meta_data($fp);
-        $path = $meta['uri'];
-
-        $container = (new GenericContainer('alpine:latest'))
-            ->withFileSystemBind($path, '/tmp/test', BindMode::READ_WRITE());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance1 = $container->start();
-
-        $container = (new GenericContainer('alpine:latest'))
-            ->withVolumesFrom($instance1, BindMode::READ_ONLY())
-            ->withCommands(['cat', '/tmp/test'])
-            ->withWaitStrategy(new LogMessageWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance2 = $container->start();
-
-        $this->assertSame("Hello, World!", $instance2->getOutput());
-    }
-
     public function testStartWithCommand()
     {
         $container = (new GenericContainer('alpine:latest'))

--- a/tests/Unit/Containers/Types/VolumeFromTest.php
+++ b/tests/Unit/Containers/Types/VolumeFromTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\Types;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\BindMode;
+use Testcontainers\Containers\Types\VolumeFrom;
+use Testcontainers\Exceptions\InvalidFormatException;
+
+class VolumeFromTest extends TestCase
+{
+    public function testVolumeFrom()
+    {
+        $volumeFrom = new VolumeFrom('container', BindMode::READ_ONLY());
+
+        $this->assertSame('container', $volumeFrom->name);
+        $this->assertSame(BindMode::$READ_ONLY, (string) $volumeFrom->mode);
+    }
+
+    public function testFromString()
+    {
+        $volumeFrom = VolumeFrom::fromString('name:ro');
+
+        $this->assertSame('name', $volumeFrom->name);
+        $this->assertSame(BindMode::$READ_ONLY, (string) $volumeFrom->mode);
+    }
+
+    public function testFromStringOnlyName()
+    {
+        $volumeFrom = VolumeFrom::fromString('name');
+
+        $this->assertSame('name', $volumeFrom->name);
+        $this->assertSame(BindMode::$READ_WRITE, (string) $volumeFrom->mode);
+    }
+
+    public function testFromStringFailedParsing()
+    {
+        $this->expectException(InvalidFormatException::class);
+
+        VolumeFrom::fromString('name:foo');
+    }
+
+
+    public function testFromArray()
+    {
+        $volumeFrom = VolumeFrom::fromArray([
+            'name' => 'name',
+            'mode' => BindMode::READ_WRITE(),
+        ]);
+
+        $this->assertSame('name', $volumeFrom->name);
+        $this->assertSame(BindMode::$READ_WRITE, (string) $volumeFrom->mode);
+    }
+
+    public function testToString()
+    {
+        $volumeFrom = new VolumeFrom('name', BindMode::READ_ONLY());
+
+        $this->assertSame('name:ro', (string) $volumeFrom);
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability to set and retrieve container names and manage container volumes more effectively by adding new traits and refactoring existing code. The most important changes include adding the `GeneralSetting` and `VolumesFromSetting` traits, updating the `GenericContainer` class to use these traits, and adding corresponding tests.

### Enhancements to Container Naming:
* [`src/Containers/Container.php`](diffhunk://#diff-fe8e987d1aa50c89af16fb40b1cc77c18c045294a9d49d5c5f63e9f3b27e8422R15-R22): Added the `withName` method to set the container name.
* [`src/Containers/GenericContainer/GeneralSetting.php`](diffhunk://#diff-cb2635aa413e9c1f85bab32bc18526ad3584b3c960eeaaa7e9391e5ba382683dR1-R67): Introduced the `GeneralSetting` trait to handle container naming with support for static variables and method chaining.

### Improvements in Volume Management:
* [`src/Containers/GenericContainer/VolumesFromSetting.php`](diffhunk://#diff-7f69487dc2b103f1064828527b3496c1b6af65b886eb7a55ea84f99456fbf92bR1-R97): Added the `VolumesFromSetting` trait to manage container volumes with support for static variables and method chaining.
* [`src/Containers/Types/VolumeFrom.php`](diffhunk://#diff-58b77a16924f07ce9235ffd2dfd0004bbce9401dce372e4c44029a4e05a07a86R1-R94): Created the `VolumeFrom` class to represent volume configurations, providing methods to parse and format volume data.

### Refactoring and Tests:
* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R39-R44): Updated the `GenericContainer` class to use the new `GeneralSetting` and `VolumesFromSetting` traits, removing redundant volume management code. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R39-R44) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L74-L88) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L244-L256) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L387-L429) [[5]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L631-L642) [[6]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L664-R588) [[7]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R632-R639)
* [`tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php`](diffhunk://#diff-30b47d8fd6b5e5814efef8d2a47cda2c8057206f9cffe06f7b74ec55fdcd8bd8R1-R84): Added unit tests for the `VolumesFromSetting` trait to ensure correct functionality.
* [`tests/Unit/Containers/Types/VolumeFromTest.php`](diffhunk://#diff-b457242e5b0f1b076587fdd7753d2ef1d1f28fcd389a9d454eda841c71aa8989R1-R63): Added unit tests for the `VolumeFrom` class to validate volume parsing and formatting.