### PR TITLE
Refactor GenericContainer to encapsulate containerId in containerDef

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -4,7 +4,6 @@ namespace Testcontainers\Containers\GenericContainer;
 
 use LogicException;
 use RuntimeException;
-use Testcontainers\Containers\BindMode;
 use Testcontainers\Containers\Container;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\ImagePullPolicy;
@@ -624,29 +623,18 @@ class GenericContainer implements Container
         if ($output->getExitCode() !== 0) {
             throw new RuntimeException('Failed to start container');
         }
-        $containerId = $output->getContainerId();
         $containerDef = [
-            'image' => $this->image,
-            'command' => $command,
-            'args' => $args,
-            'name' => $this->name(),
-            'hosts' => $hosts,
-            'env' => $this->env(),
+            'containerId' => $output->getContainerId(),
             'labels' => $this->labels(),
-            'mounts' => $this->mounts(),
-            'networkMode' => $this->networkMode(),
-            'networkAliases' => $this->networkAliases(),
-            'volumesFrom' => $this->volumesFrom(),
             'ports' => array_reduce($ports, function ($carry, $item) {
                 $parts = explode(':', $item);
                 $carry[(int)$parts[1]] = (int)$parts[0];
                 return $carry;
             }, []),
             'pull' => $this->pullPolicy(),
-            'workdir' => $this->workDir(),
             'privileged' => $this->privileged(),
         ];
-        $instance = new GenericContainerInstance($containerId, $containerDef);
+        $instance = new GenericContainerInstance($containerDef);
         $instance->setDockerClient($client);
 
         $startupCheckStrategy = $this->startupCheckStrategy();

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -6,19 +6,23 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\ImagePullPolicy;
+use Testcontainers\Docker\Types\ContainerId;
 
 class GenericContainerInstanceTest extends TestCase
 {
     public function testGetContainerId()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
 
         $this->assertSame('8188d93d8a27', (string) $instance->getContainerId());
     }
 
     public function testGetLabel()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'labels' => [
                 'com.example.label' => 'value',
             ],
@@ -29,7 +33,8 @@ class GenericContainerInstanceTest extends TestCase
 
     public function testGetLabels()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'labels' => [
                 'com.example.label' => 'value',
             ],
@@ -40,14 +45,17 @@ class GenericContainerInstanceTest extends TestCase
 
     public function testGetHost()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
 
         $this->assertSame('localhost', $instance->getHost());
     }
 
     public function testGetMappedPort()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'ports' => [
                 80 => 8080,
             ],
@@ -59,7 +67,8 @@ class GenericContainerInstanceTest extends TestCase
     public function testGetImagePullPolicy()
     {
         $pullPolicy = ImagePullPolicy::ALWAYS();
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'pull' => $pullPolicy,
         ]);
 
@@ -68,7 +77,8 @@ class GenericContainerInstanceTest extends TestCase
 
     public function testGetPrivilegedMode()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'privileged' => true,
         ]);
 
@@ -107,7 +117,9 @@ class GenericContainerInstanceTest extends TestCase
     {
         $data = new CustomData();
 
-        $instance = new GenericContainerInstance('8188d93d8a27');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
         $instance->setData($data);
 
         $this->assertSame($data, $instance->getData(CustomData::class));
@@ -115,14 +127,18 @@ class GenericContainerInstanceTest extends TestCase
 
     public function testIsRunning()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
 
         $this->assertFalse($instance->isRunning());
     }
 
     public function testStop()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
         $instance->stop();
 
         $this->assertFalse($instance->isRunning());

--- a/tests/Unit/Containers/WaitStrategy/HostPortWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/HostPortWaitStrategyTest.php
@@ -6,6 +6,7 @@ use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
 use Testcontainers\Containers\WaitStrategy\PortProbe;
 use Testcontainers\Containers\WaitStrategy\WaitingTimeoutException;
+use Testcontainers\Docker\Types\ContainerId;
 
 class HostPortWaitStrategyTest extends WaitStrategyTestCase
 {
@@ -19,7 +20,8 @@ class HostPortWaitStrategyTest extends WaitStrategyTestCase
 
     public function testWaitUntilReady()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'ports' => [80 => 8239],
         ]);
         $probe = $this->createMock(PortProbe::class);
@@ -35,7 +37,8 @@ class HostPortWaitStrategyTest extends WaitStrategyTestCase
     {
         $this->expectException(WaitingTimeoutException::class);
 
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'ports' => [80 => 8239],
         ]);
         $strategy = (new HostPortWaitStrategy())->withTimeoutSeconds(0);

--- a/tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Containers\WaitStrategy;
 use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\WaitStrategy\HttpProbe;
 use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
+use Testcontainers\Docker\Types\ContainerId;
 
 class HttpWaitStrategyTest extends WaitStrategyTestCase
 {
@@ -18,7 +19,8 @@ class HttpWaitStrategyTest extends WaitStrategyTestCase
 
     public function testWaitUntilReady()
     {
-        $instance = new GenericContainerInstance('8188d93d8a27', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'ports' => [80 => 8239],
         ]);
         $probe = $this->createMock(HttpProbe::class);

--- a/tests/Unit/Containers/WaitStrategy/LogMessageWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/LogMessageWaitStrategyTest.php
@@ -25,7 +25,9 @@ class LogMessageWaitStrategyTest extends WaitStrategyTestCase
         $containerId = $output->getContainerId();
 
         try {
-            $instance = new GenericContainerInstance($containerId);
+            $instance = new GenericContainerInstance([
+                'containerId' => $containerId,
+            ]);
             $strategy = (new LogMessageWaitStrategy())
                 ->withPattern('\d{2}:\d{2}:\d{2}')
                 ->withTimeoutSeconds(5);

--- a/tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php
@@ -6,6 +6,7 @@ use LogicException;
 use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\WaitStrategy\PDO\PDOConnectWaitStrategy;
 use Testcontainers\Containers\WaitStrategy\PDO\SQLiteDSN;
+use Testcontainers\Docker\Types\ContainerId;
 use Tests\Unit\Containers\WaitStrategy\WaitStrategyTestCase;
 
 class PDOConnectWaitStrategyTest extends WaitStrategyTestCase
@@ -21,7 +22,8 @@ class PDOConnectWaitStrategyTest extends WaitStrategyTestCase
 
     public function testWaitUntilReady()
     {
-        $instance = new GenericContainerInstance('818b7f3b1b3b', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'ports' => [3306 => 3306],
         ]);
         $strategy = $this->resolveWaitStrategy();
@@ -34,7 +36,8 @@ class PDOConnectWaitStrategyTest extends WaitStrategyTestCase
     {
         $this->expectException(LogicException::class);
 
-        $instance = new GenericContainerInstance('818b7f3b1b3b', [
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
             'ports' => [3306 => 3306],
         ]);
         $strategy = new PDOConnectWaitStrategy();
@@ -45,7 +48,9 @@ class PDOConnectWaitStrategyTest extends WaitStrategyTestCase
     {
         $this->expectException(LogicException::class);
 
-        $instance = new GenericContainerInstance('818b7f3b1b3b');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
         $strategy = $this->resolveWaitStrategy();
         $strategy->waitUntilReady($instance);
     }


### PR DESCRIPTION
This pull request refactors the `GenericContainer` and `GenericContainerInstance` classes by removing the `containerId` property and incorporating it into the `containerDef` array. Additionally, it updates the associated unit tests to reflect these changes.

Refactoring of `GenericContainer` and `GenericContainerInstance`:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L627-R637): Removed the `containerId` variable and moved its value into the `containerDef` array.
* [`src/Containers/GenericContainer/GenericContainerInstance.php`](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL25-R34): Removed the `containerId` property and updated methods to retrieve the container ID from the `containerDef` array. [[1]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL25-R34) [[2]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL63-L83) [[3]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL108-R89) [[4]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL204-R185) [[5]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL214-R195) [[6]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL251-R232) [[7]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL275-R256)

Unit test updates:

* [`tests/Unit/Containers/GenericContainerInstanceTest.php`](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R9-R25): Updated test cases to pass the `containerId` within the `containerDef` array instead of as a separate parameter. [[1]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R9-R25) [[2]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L32-R37) [[3]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L43-R58) [[4]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L62-R71) [[5]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L71-R81) [[6]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L110-R141)
* [`tests/Unit/Containers/WaitStrategy/HostPortWaitStrategyTest.php`](diffhunk://#diff-2c1cace1d19f35390d140978d3cbed0c9dd74275666d69c805263c39b03952a2R9): Modified test cases to align with the new `containerDef` structure. [[1]](diffhunk://#diff-2c1cace1d19f35390d140978d3cbed0c9dd74275666d69c805263c39b03952a2R9) [[2]](diffhunk://#diff-2c1cace1d19f35390d140978d3cbed0c9dd74275666d69c805263c39b03952a2L22-R24) [[3]](diffhunk://#diff-2c1cace1d19f35390d140978d3cbed0c9dd74275666d69c805263c39b03952a2L38-R41)
* [`tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php`](diffhunk://#diff-1eed85d1aee706cfc970731521c6d1447bf7af7fc243552f39bbc5290b6ce874R8): Adjusted test cases to use the updated `containerDef` array. [[1]](diffhunk://#diff-1eed85d1aee706cfc970731521c6d1447bf7af7fc243552f39bbc5290b6ce874R8) [[2]](diffhunk://#diff-1eed85d1aee706cfc970731521c6d1447bf7af7fc243552f39bbc5290b6ce874L21-R23)
* [`tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php`](diffhunk://#diff-ec07efa62f944681a16e54ed7c6070351616ef1b7b92623888537bf6a5ae8143R9): Updated test cases to reflect the changes in the `containerDef` array structure. [[1]](diffhunk://#diff-ec07efa62f944681a16e54ed7c6070351616ef1b7b92623888537bf6a5ae8143R9) [[2]](diffhunk://#diff-ec07efa62f944681a16e54ed7c6070351616ef1b7b92623888537bf6a5ae8143L24-R26) [[3]](diffhunk://#diff-ec07efa62f944681a16e54ed7c6070351616ef1b7b92623888537bf6a5ae8143L37-R40) [[4]](diffhunk://#diff-ec07efa62f944681a16e54ed7c6070351616ef1b7b92623888537bf6a5ae8143L48-R53)