### PR TITLE
Refactor label management with new LabelSetting trait

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -37,6 +37,7 @@ class GenericContainer implements Container
     use ExposedPortSetting;
     use GeneralSetting;
     use HostSetting;
+    use LabelSetting;
     use MountSetting;
     use NetworkAliasSetting;
     use NetworkModeSetting;
@@ -71,18 +72,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default labels to be used for the container.
-     * @var array<string, string>|null
-     */
-    protected static $LABELS;
-
-    /**
-     * The labels to be used for the container.
-     * @var array<string, string>
-     */
-    private $labels = [];
 
     /**
      * Define the default image pull policy to be used for the container.
@@ -230,26 +219,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withLabel($key, $value)
-    {
-        $this->labels[$key] = $value;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withLabels($labels)
-    {
-        $this->labels = $labels;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withCommand($cmd)
     {
         $this->commands = [$cmd];
@@ -353,26 +322,6 @@ class GenericContainer implements Container
         }
         if ($this->commands) {
             return $this->commands;
-        }
-        return null;
-    }
-
-    /**
-     * Retrieve the labels for the container.
-     *
-     * This method returns the labels that should be used for the container.
-     * If specific labels are set, it will return those. Otherwise, it will
-     * attempt to retrieve the default labels from the provider.
-     *
-     * @return array<string, string>|null The labels to be used, or null if none are set.
-     */
-    protected function labels()
-    {
-        if (static::$LABELS) {
-            return static::$LABELS;
-        }
-        if ($this->labels) {
-            return $this->labels;
         }
         return null;
     }

--- a/src/Containers/GenericContainer/LabelSetting.php
+++ b/src/Containers/GenericContainer/LabelSetting.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+/**
+ * LabelSetting is a trait that provides the ability to set labels for a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$LABELS`:
+ *
+ * <code>
+ * class YourContainer extends GenericContainer
+ * {
+ *     protected static $LABELS = [
+ *         'com.example.label' => 'value',
+ *     ];
+ * }
+ * </code>
+ *
+ * 2. method `withLabel`:
+ *
+ * <code>
+ * $container = (new YourContainer('image'))
+ *     ->withLabel('com.example.label', 'value');
+ * </code>
+ */
+trait LabelSetting
+{
+    /**
+     * Define the default labels to be used for the container.
+     * @var array<string, string>|null
+     */
+    protected static $LABELS;
+
+    /**
+     * The labels to be used for the container.
+     * @var array<string, string>
+     */
+    private $labels = [];
+
+    /**
+     * Add a label to the container.
+     *
+     * @param string $key The name of the label.
+     * @param string $value The value of the label.
+     * @return self
+     */
+    public function withLabel($key, $value)
+    {
+        $this->labels[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Adds multiple labels to the container.
+     *
+     * @param array<string, string> $labels An associative array where the key is the label name and the value is the label value.
+     * @return self
+     */
+    public function withLabels($labels)
+    {
+        $this->labels = $labels;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the labels for the container.
+     *
+     * This method returns the labels that should be used for the container.
+     * If specific labels are set, it will return those. Otherwise, it will
+     * attempt to retrieve the default labels from the provider.
+     *
+     * @return array<string, string>|null The labels to be used, or null if none are set.
+     */
+    protected function labels()
+    {
+        if (static::$LABELS) {
+            return static::$LABELS;
+        }
+        if ($this->labels) {
+            return $this->labels;
+        }
+        return null;
+    }
+}

--- a/tests/Unit/Containers/GenericContainer/LabelSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/LabelSettingTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\LabelSetting;
+use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
+
+class LabelSettingTest extends TestCase
+{
+    public function testHasEnvSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(LabelSetting::class, $uses);
+    }
+
+    public function testStaticLabels()
+    {
+        $container = new LabelSettingWithStaticLabelsContainer('alpine:latest');
+        $instance = $container->start();
+
+        $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
+        $this->assertSame("VALUE2", $instance->getLabel('KEY2'));
+    }
+
+    public function testStartWithLabel()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withLabel('KEY1', 'VALUE1')
+            ->withLabel('KEY2', 'VALUE2')
+            ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $instance = $container->start();
+
+        $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
+        $this->assertSame("VALUE2", $instance->getLabel('KEY2'));
+    }
+
+
+    public function testStartWithLabels()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $instance = $container->start();
+
+        $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
+        $this->assertSame("VALUE2", $instance->getLabel('KEY2'));
+        $this->assertSame(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'], $instance->getLabels());
+    }
+}
+
+class LabelSettingWithStaticLabelsContainer extends GenericContainer
+{
+    protected static $LABELS = [
+        'KEY1' => 'VALUE1',
+        'KEY2' => 'VALUE2',
+    ];
+}

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -70,19 +70,6 @@ class GenericContainerTest extends TestCase
         $this->assertStringStartsWith('PING my-alias', $instance->getOutput());
     }
 
-    public function testStartWithLabels()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
-            ->withWaitStrategy(new LogMessageWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
-        $this->assertSame("VALUE2", $instance->getLabel('KEY2'));
-        $this->assertSame(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'], $instance->getLabels());
-    }
-
     public function testStartWithExposedPorts()
     {
         $container = (new GenericContainer('alpine:latest'))


### PR DESCRIPTION
This pull request introduces the `LabelSetting` trait to the `GenericContainer` class, refactoring the label-related functionality into a separate trait, and includes corresponding tests for the new trait. The most important changes include adding the `LabelSetting` trait to the `GenericContainer`, removing the label-related methods and properties from the `GenericContainer`, and creating a new test class for label-related functionality.

Refactoring and code organization:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R40): Added the `LabelSetting` trait to the `GenericContainer` class and removed label-related methods and properties. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R40) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L75-L86) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L230-L249) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L360-L379)

New functionality:

* [`src/Containers/GenericContainer/LabelSetting.php`](diffhunk://#diff-22bec4a59ac59b4748c18411df05cb04fc2ac73d256afdd442c6bcfca478028aR1-R87): Introduced the `LabelSetting` trait to encapsulate label-related functionality, including methods for adding and retrieving labels.

Testing:

* [`tests/Unit/Containers/GenericContainer/LabelSettingTest.php`](diffhunk://#diff-7d00d6530ad878388bf7ec66484b2c260951a5adc842063e70bb5886d3dc1e60R1-R64): Created a new test class to verify the functionality of the `LabelSetting` trait, including tests for static labels and dynamic label setting.
* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L73-L85): Removed the label-related test method, as it has been moved to the new `LabelSettingTest` class.