### PR TITLE
Refactor image pull policy with new PullPolicySetting trait

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -6,7 +6,6 @@ use LogicException;
 use RuntimeException;
 use Testcontainers\Containers\Container;
 use Testcontainers\Containers\ContainerInstance;
-use Testcontainers\Containers\ImagePullPolicy;
 use Testcontainers\Containers\PortStrategy\AlreadyExistsPortStrategyException;
 use Testcontainers\Containers\PortStrategy\LocalRandomPortStrategy;
 use Testcontainers\Containers\PortStrategy\PortStrategy;
@@ -41,6 +40,7 @@ class GenericContainer implements Container
     use MountSetting;
     use NetworkAliasSetting;
     use NetworkModeSetting;
+    use PullPolicySetting;
     use VolumesFromSetting;
 
     /**
@@ -72,18 +72,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default image pull policy to be used for the container.
-     * @var ImagePullPolicy|null
-     */
-    protected static $PULL_POLICY;
-
-    /**
-     * The image pull policy to be used for the container.
-     * @var ImagePullPolicy|null
-     */
-    private $pullPolicy;
 
     /**
      * Define the default working directory to be used for the container.
@@ -239,16 +227,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withImagePullPolicy($policy)
-    {
-        $this->pullPolicy = $policy;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withWorkingDirectory($workDir)
     {
         $this->workDir = $workDir;
@@ -324,23 +302,6 @@ class GenericContainer implements Container
             return $this->commands;
         }
         return null;
-    }
-
-    /**
-     * Retrieve the image pull policy for the container.
-     *
-     * This method returns the image pull policy that should be used for the container.
-     * If a specific image pull policy is set, it will return that. Otherwise, it will
-     * attempt to retrieve the default image pull policy from the provider.
-     *
-     * @return ImagePullPolicy|null The image pull policy to be used, or null if none is set.
-     */
-    protected function pullPolicy()
-    {
-        if (static::$PULL_POLICY) {
-            return static::$PULL_POLICY;
-        }
-        return $this->pullPolicy;
     }
 
     /**

--- a/src/Containers/GenericContainer/PullPolicySetting.php
+++ b/src/Containers/GenericContainer/PullPolicySetting.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+use Testcontainers\Containers\ImagePullPolicy;
+use Testcontainers\Exceptions\InvalidFormatException;
+
+/**
+ * PullPolicySetting is a trait that provides the ability to set the image pull policy for a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$PULL_POLICY`:
+ *
+ * <code>
+ *     class YourContainer extends GenericContainer
+ *     {
+ *         protected static $PULL_POLICY = 'always';
+ *     }
+ * </code>
+ *
+ * 2. method `withImagePullPolicy`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *         ->withImagePullPolicy(ImagePullPolicy::ALWAYS());
+ * </code>
+ */
+trait PullPolicySetting
+{
+    /**
+     * Define the default image pull policy to be used for the container.
+     * @var string|null
+     */
+    protected static $PULL_POLICY;
+
+    /**
+     * The image pull policy to be used for the container.
+     * @var ImagePullPolicy|null
+     */
+    private $pullPolicy;
+
+    /**
+     * Set the image pull policy of the container.
+     *
+     * @param ImagePullPolicy $policy The image pull policy to set.
+     * @return self
+     */
+    public function withImagePullPolicy($policy)
+    {
+        $this->pullPolicy = $policy;
+
+        return $this;
+    }
+
+
+    /**
+     * Set the image pull policy of the container. (Alias for `withImagePullPolicy`)
+     *
+     * @param ImagePullPolicy $policy The image pull policy to set.
+     * @return self
+     */
+    public function withPullPolicy($policy)
+    {
+        return $this->withImagePullPolicy($policy);
+    }
+
+    /**
+     * Retrieve the image pull policy for the container.
+     *
+     * This method returns the image pull policy that should be used for the container.
+     * If a specific image pull policy is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default image pull policy from the provider.
+     *
+     * @return ImagePullPolicy|null The image pull policy to be used, or null if none is set.
+     *
+     * @throws InvalidFormatException If the image pull policy is not valid.
+     */
+    protected function pullPolicy()
+    {
+        if (static::$PULL_POLICY) {
+            return ImagePullPolicy::fromString(static::$PULL_POLICY);
+        }
+        return $this->pullPolicy;
+    }
+}

--- a/src/Containers/GenericContainer/VolumesFromSetting.php
+++ b/src/Containers/GenericContainer/VolumesFromSetting.php
@@ -2,7 +2,6 @@
 
 namespace Testcontainers\Containers\GenericContainer;
 
-use InvalidArgumentException;
 use Testcontainers\Containers\BindMode;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\Types\VolumeFrom;

--- a/tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\PullPolicySetting;
+use Testcontainers\Containers\ImagePullPolicy;
+
+class PullPolicySettingTest extends TestCase
+{
+    public function testHasPullPolicySettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(PullPolicySetting::class, $uses);
+    }
+
+    public function testStaticPullPolicy()
+    {
+        $container = new PullPolicySettingWithStaticPullPolicyContainer('alpine:latest');
+        $instance = $container->start();
+
+        $this->assertSame(ImagePullPolicy::$ALWAYS, $instance->getImagePullPolicy()->toString());
+    }
+
+    public function testStartWithImagePullPolicy()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withImagePullPolicy(ImagePullPolicy::MISSING());
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $instance = $container->start();
+
+        $this->assertSame(ImagePullPolicy::$MISSING, $instance->getImagePullPolicy()->toString());
+    }
+}
+
+class PullPolicySettingWithStaticPullPolicyContainer extends GenericContainer
+{
+    protected static $PULL_POLICY = 'always';
+}

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -101,16 +101,6 @@ class GenericContainerTest extends TestCase
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
     }
 
-    public function testStartWithImagePullPolicy()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withImagePullPolicy(ImagePullPolicy::MISSING());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertSame(ImagePullPolicy::$MISSING, $instance->getImagePullPolicy()->toString());
-    }
-
     public function testStartWithWorkingDirectory()
     {
         $container = (new GenericContainer('alpine:latest'))


### PR DESCRIPTION
This pull request refactors the image pull policy functionality in the `GenericContainer` class by moving it to a new trait, `PullPolicySetting`. This change simplifies the `GenericContainer` class and improves modularity. The most important changes include the removal of image pull policy methods and variables from `GenericContainer`, the addition of the `PullPolicySetting` trait, and the update of related tests.

Refactoring of image pull policy functionality:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L9): Removed image pull policy methods and variables from the `GenericContainer` class and added the `PullPolicySetting` trait. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L9) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R43) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L76-L87) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L239-L248) [[5]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L329-L345)

Addition of `PullPolicySetting` trait:

* [`src/Containers/GenericContainer/PullPolicySetting.php`](diffhunk://#diff-df560207fa7a0a4affa27b90105ba64cbf0acce250eff9d3bd1391c03208302bR1-R85): Added a new trait `PullPolicySetting` that provides the ability to set and retrieve the image pull policy for a container.

Update of related tests:

* [`tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php`](diffhunk://#diff-4597ca68365d6df00d6a6e0e4e49c8ee9ad50d1540edad807ec3a254c76aadd5R1-R43): Added new tests for the `PullPolicySetting` trait to ensure it works as expected.
* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L104-L113): Removed the test for the image pull policy from the `GenericContainerTest` class as it is now covered by the `PullPolicySettingTest`.

Minor cleanup:

* [`src/Containers/GenericContainer/VolumesFromSetting.php`](diffhunk://#diff-7f69487dc2b103f1064828527b3496c1b6af65b886eb7a55ea84f99456fbf92bL5): Removed an unused import statement.