### PR TITLE
Add PrivilegeSetting trait and refactor GenericContainer for modular privileged mode handling

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -40,6 +40,7 @@ class GenericContainer implements Container
     use MountSetting;
     use NetworkAliasSetting;
     use NetworkModeSetting;
+    use PrivilegeSetting;
     use PullPolicySetting;
     use VolumesFromSetting;
 
@@ -96,20 +97,6 @@ class GenericContainer implements Container
      * @var int|null
      */
     private $startupTimeout;
-
-    /**
-     * Define the default privileged mode to be used for the container.
-     *
-     * @var bool|null
-     */
-    protected static $PRIVILEGED;
-
-    /**
-     * The privileged mode to be used for the container.
-     *
-     * @var bool
-     */
-    private $privileged = false;
 
     /**
      * Define the default startup check strategy to be used for the container.
@@ -247,16 +234,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withPrivilegedMode($mode)
-    {
-        $this->privileged = $mode;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withStartupCheckStrategy($strategy)
     {
         $this->startupCheckStrategy = $strategy;
@@ -328,23 +305,6 @@ class GenericContainer implements Container
             return static::$STARTUP_TIMEOUT;
         }
         return $this->startupTimeout;
-    }
-
-    /**
-     * Retrieve the privileged mode for the container.
-     *
-     * This method returns whether the container should run in privileged mode.
-     * If a specific privileged mode is set, it will return that. Otherwise, it will
-     * attempt to retrieve the default privileged mode from the provider.
-     *
-     * @return bool True if the container should run in privileged mode, false otherwise.
-     */
-    protected function privileged()
-    {
-        if (static::$PRIVILEGED) {
-            return static::$PRIVILEGED;
-        }
-        return $this->privileged;
     }
 
     /**

--- a/src/Containers/GenericContainer/PrivilegeSetting.php
+++ b/src/Containers/GenericContainer/PrivilegeSetting.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+/**
+ * PrivilegeSetting is a trait that provides the ability to run a container in privileged mode.
+ *
+ * Two formats are supported:
+ * 1. static variable `$PRIVILEGED`:
+ *
+ * <code>
+ * class YourContainer extends GenericContainer
+ * {
+ *     protected static $PRIVILEGED = true;
+ * }
+ * </code>
+ *
+ * 2. method `withPrivilegedMode`:
+ *
+ * <code>
+ * $container = (new YourContainer('image'))
+ *     ->withPrivilegedMode(true);
+ * </code>
+ */
+trait PrivilegeSetting
+{
+    /**
+     * Define the default privileged mode to be used for the container.
+     *
+     * @var bool|null
+     */
+    protected static $PRIVILEGED;
+
+    /**
+     * The privileged mode to be used for the container.
+     *
+     * @var bool
+     */
+    private $privileged = false;
+
+    /**
+     * Set the privileged mode for the container.
+     *
+     * @param boolean $mode Whether to enable privileged mode.
+     * @return self
+     */
+    public function withPrivilegedMode($mode)
+    {
+        $this->privileged = $mode;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the privileged mode for the container.
+     *
+     * This method returns whether the container should run in privileged mode.
+     * If a specific privileged mode is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default privileged mode from the provider.
+     *
+     * @return bool True if the container should run in privileged mode, false otherwise.
+     */
+    protected function privileged()
+    {
+        if (static::$PRIVILEGED) {
+            return static::$PRIVILEGED;
+        }
+        return $this->privileged;
+    }
+}

--- a/tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\PrivilegeSetting;
+
+class PrivilegeSettingTest extends TestCase
+{
+    public function testHasPrivilegeSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(PrivilegeSetting::class, $uses);
+    }
+
+    public function testStaticPrivileged()
+    {
+        $container = new PrivilegeSettingWithStaticPrivilegedContainer('alpine:latest');
+        $instance = $container->start();
+
+        $this->assertSame(true, $instance->getPrivilegedMode());
+    }
+
+    public function testStartWithPrivilegedMode()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withPrivilegedMode(true);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $instance = $container->start();
+
+        $this->assertSame(true, $instance->getPrivilegedMode());
+    }
+}
+
+class PrivilegeSettingWithStaticPrivilegedContainer extends GenericContainer
+{
+    protected static $PRIVILEGED = true;
+}

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -123,14 +123,4 @@ class GenericContainerTest extends TestCase
         /** @noinspection PhpUnhandledExceptionInspection */
         $container->start();
     }
-
-    public function testStartWithPrivilegedMode()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withPrivilegedMode(true);
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertSame(true, $instance->getPrivilegedMode());
-    }
 }


### PR DESCRIPTION
This pull request refactors the `GenericContainer` class by extracting the privileged mode functionality into a new trait called `PrivilegeSetting`. This change aims to improve code modularity and maintainability. Additionally, new unit tests have been added to ensure the functionality of the `PrivilegeSetting` trait.

Refactoring and modularization:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R43): Removed the privileged mode properties and methods from the `GenericContainer` class and added the `PrivilegeSetting` trait. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R43) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L100-L113) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L247-L256) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L333-L349)
* [`src/Containers/GenericContainer/PrivilegeSetting.php`](diffhunk://#diff-4011beb50ac87708ed49a812416a03ed9fbaee124cf0261c2a1059972b68532dR1-R70): Created the `PrivilegeSetting` trait to encapsulate the privileged mode functionality, including properties and methods for setting and retrieving the privileged mode.

Testing:

* [`tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php`](diffhunk://#diff-36977976ec3f7a5fe86736e2b5b206938c576f5bd2e6b0363687f63bccd8545bR1-R42): Added new unit tests to verify the behavior of the `PrivilegeSetting` trait, including tests for static and instance-based privileged mode settings.
* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5L126-L135): Removed the privileged mode test from the `GenericContainerTest` class as it is now covered in the `PrivilegeSettingTest` class.