### PR TITLE
Refactor startupstrategy gc

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -10,9 +10,6 @@ use Testcontainers\Containers\PortStrategy\AlreadyExistsPortStrategyException;
 use Testcontainers\Containers\PortStrategy\LocalRandomPortStrategy;
 use Testcontainers\Containers\PortStrategy\PortStrategy;
 use Testcontainers\Containers\PortStrategy\PortStrategyProvider;
-use Testcontainers\Containers\StartupCheckStrategy\AlreadyExistsStartupStrategyException;
-use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
-use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategyProvider;
 use Testcontainers\Containers\WaitStrategy\AlreadyExistsWaitStrategyException;
 use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
 use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
@@ -114,7 +111,6 @@ class GenericContainer implements Container
     /**
      * @param string|null $image The image to be used for the container.
      *
-     * @throws AlreadyExistsStartupStrategyException if the startup strategy already exists.
      * @throws AlreadyExistsPortStrategyException if the port strategy already exists.
      * @throws AlreadyExistsWaitStrategyException if the wait strategy already exists.
      */
@@ -123,10 +119,6 @@ class GenericContainer implements Container
         assert($image || static::$IMAGE);
 
         $this->image = $image ?: static::$IMAGE;
-
-        $this->startupCheckStrategyProvider = new StartupCheckStrategyProvider();
-        $this->startupCheckStrategyProvider->register('is_running', new IsRunningStartupCheckStrategy());
-        $this->registerStartupCheckStrategy($this->startupCheckStrategyProvider);
 
         $this->portStrategyProvider = new PortStrategyProvider();
         $this->portStrategyProvider->register(new LocalRandomPortStrategy());

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -12,7 +12,6 @@ use Testcontainers\Containers\PortStrategy\PortStrategy;
 use Testcontainers\Containers\PortStrategy\PortStrategyProvider;
 use Testcontainers\Containers\StartupCheckStrategy\AlreadyExistsStartupStrategyException;
 use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
-use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategy;
 use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategyProvider;
 use Testcontainers\Containers\WaitStrategy\AlreadyExistsWaitStrategyException;
 use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
@@ -127,6 +126,7 @@ class GenericContainer implements Container
 
         $this->startupCheckStrategyProvider = new StartupCheckStrategyProvider();
         $this->startupCheckStrategyProvider->register('is_running', new IsRunningStartupCheckStrategy());
+        $this->registerStartupCheckStrategy($this->startupCheckStrategyProvider);
 
         $this->portStrategyProvider = new PortStrategyProvider();
         $this->portStrategyProvider->register(new LocalRandomPortStrategy());

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -126,7 +126,7 @@ class GenericContainer implements Container
         $this->image = $image ?: static::$IMAGE;
 
         $this->startupCheckStrategyProvider = new StartupCheckStrategyProvider();
-        $this->startupCheckStrategyProvider->register(new IsRunningStartupCheckStrategy());
+        $this->startupCheckStrategyProvider->register('is_running', new IsRunningStartupCheckStrategy());
 
         $this->portStrategyProvider = new PortStrategyProvider();
         $this->portStrategyProvider->register(new LocalRandomPortStrategy());

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -42,6 +42,7 @@ class GenericContainer implements Container
     use NetworkModeSetting;
     use PrivilegeSetting;
     use PullPolicySetting;
+    use StartupSetting;
     use VolumesFromSetting;
     use WorkdirSetting;
 
@@ -74,36 +75,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default startup timeout to be used for the container.
-     * @var int|null
-     */
-    protected static $STARTUP_TIMEOUT;
-
-    /**
-     * The startup timeout to be used for the container.
-     * @var int|null
-     */
-    private $startupTimeout;
-
-    /**
-     * Define the default startup check strategy to be used for the container.
-     * @var string|null
-     */
-    protected static $STARTUP_CHECK_STRATEGY;
-
-    /**
-     * The startup check strategy to be used for the container.
-     * @var StartupCheckStrategy|null
-     */
-    private $startupCheckStrategy;
-
-    /**
-     * The startup check strategy provider.
-     * @var StartupCheckStrategyProvider
-     */
-    private $startupCheckStrategyProvider;
 
     /**
      * Define the default port strategy to be used for the container.
@@ -203,26 +174,6 @@ class GenericContainer implements Container
     /**
      * {@inheritdoc}
      */
-    public function withStartupTimeout($timeout)
-    {
-        $this->startupTimeout = $timeout;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withStartupCheckStrategy($strategy)
-    {
-        $this->startupCheckStrategy = $strategy;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function withPortStrategy($strategy)
     {
         $this->portStrategy = $strategy;
@@ -256,43 +207,6 @@ class GenericContainer implements Container
         }
         if ($this->commands) {
             return $this->commands;
-        }
-        return null;
-    }
-
-    /**
-     * Retrieve the startup timeout for the container.
-     *
-     * @return int|null
-     */
-    protected function startupTimeout()
-    {
-        if (static::$STARTUP_TIMEOUT) {
-            return static::$STARTUP_TIMEOUT;
-        }
-        return $this->startupTimeout;
-    }
-
-    /**
-     * Retrieve the startup check strategy for the container.
-     *
-     * This method returns the startup check strategy that should be used for the container.
-     * If a specific startup check strategy is set, it will return that. Otherwise, it will
-     * attempt to retrieve the default startup check strategy from the provider.
-     *
-     * @return StartupCheckStrategy|null The startup check strategy to be used, or null if none is set.
-     */
-    protected function startupCheckStrategy()
-    {
-        if (static::$STARTUP_CHECK_STRATEGY !== null) {
-            $strategy = $this->startupCheckStrategyProvider->get(static::$STARTUP_CHECK_STRATEGY);
-            if (!$strategy) {
-                throw new LogicException("Startup check strategy not found: " . static::$STARTUP_CHECK_STRATEGY);
-            }
-            return $strategy;
-        }
-        if ($this->startupCheckStrategy) {
-            return $this->startupCheckStrategy;
         }
         return null;
     }

--- a/src/Containers/GenericContainer/StartupSetting.php
+++ b/src/Containers/GenericContainer/StartupSetting.php
@@ -123,4 +123,14 @@ trait StartupSetting
         }
         return null;
     }
+
+    /**
+     * Register a startup check strategy.
+     *
+     * @param StartupCheckStrategyProvider $provider The startup check strategy provider.
+     */
+    protected function registerStartupCheckStrategy($provider)
+    {
+        // Override this method to register custom startup strategies
+    }
 }

--- a/src/Containers/GenericContainer/StartupSetting.php
+++ b/src/Containers/GenericContainer/StartupSetting.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+use LogicException;
+use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategy;
+use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategyProvider;
+
+/**
+ * StartupSetting is a trait that provides the ability to set the startup timeout and check strategy for a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$STARTUP_TIMEOUT` and `$STARTUP_CHECK_STRATEGY`:
+ *
+ * <code>
+ * class YourContainer extends GenericContainer
+ * {
+ *     protected static $STARTUP_TIMEOUT = 30;
+ *
+ *     protected static $STARTUP_CHECK_STRATEGY = 'is_running';
+ * }
+ * </code>
+ *
+ * 2. method `withStartupTimeout` and `withStartupCheckStrategy`:
+ *
+ * <code>
+ * $container = (new YourContainer('image'))
+ *     ->withStartupTimeout(30)
+ *     ->withStartupCheckStrategy(new IsRunningStartupCheckStrategy());
+ * </code>
+ */
+trait StartupSetting
+{
+    /**
+     * Define the default startup timeout to be used for the container.
+     * @var int|null
+     */
+    protected static $STARTUP_TIMEOUT;
+
+    /**
+     * The startup timeout to be used for the container.
+     * @var int|null
+     */
+    private $startupTimeout;
+
+    /**
+     * Define the default startup check strategy to be used for the container.
+     * @var string|null
+     */
+    protected static $STARTUP_CHECK_STRATEGY;
+
+    /**
+     * The startup check strategy to be used for the container.
+     * @var StartupCheckStrategy|null
+     */
+    private $startupCheckStrategy;
+
+    /**
+     * The startup check strategy provider.
+     * @var StartupCheckStrategyProvider
+     */
+    private $startupCheckStrategyProvider;
+
+    /**
+     * Set the duration of waiting time until the container is treated as started.
+     *
+     * @param int $timeout The duration to wait.
+     * @return self
+     */
+    public function withStartupTimeout($timeout)
+    {
+        $this->startupTimeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Set the startup check strategy used for checking whether the container has started.
+     *
+     * @param StartupCheckStrategy $strategy The startup check strategy to use.
+     * @return self
+     */
+    public function withStartupCheckStrategy($strategy)
+    {
+        $this->startupCheckStrategy = $strategy;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the startup timeout for the container.
+     *
+     * @return int|null
+     */
+    protected function startupTimeout()
+    {
+        if (static::$STARTUP_TIMEOUT) {
+            return static::$STARTUP_TIMEOUT;
+        }
+        return $this->startupTimeout;
+    }
+
+    /**
+     * Retrieve the startup check strategy for the container.
+     *
+     * This method returns the startup check strategy that should be used for the container.
+     * If a specific startup check strategy is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default startup check strategy from the provider.
+     *
+     * @return StartupCheckStrategy|null The startup check strategy to be used, or null if none is set.
+     */
+    protected function startupCheckStrategy()
+    {
+        if (static::$STARTUP_CHECK_STRATEGY !== null) {
+            $strategy = $this->startupCheckStrategyProvider->get(static::$STARTUP_CHECK_STRATEGY);
+            if (!$strategy) {
+                throw new LogicException("Startup check strategy not found: " . static::$STARTUP_CHECK_STRATEGY);
+            }
+            return $strategy;
+        }
+        if ($this->startupCheckStrategy) {
+            return $this->startupCheckStrategy;
+        }
+        return null;
+    }
+}

--- a/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
@@ -20,12 +20,12 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
     /**
      * {@inheritdoc}
      */
-    public function waitUntilStartupSuccessful($containerId)
+    public function waitUntilStartupSuccessful($instance)
     {
         $client = $this->client ?: DockerClientFactory::create();
         try {
             while (true) {
-                $output = $client->inspect($containerId);
+                $output = $client->inspect($instance->getContainerId());
                 switch ($output->state->status) {
                     case 'running':
                         return true;

--- a/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
@@ -52,12 +52,4 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
         $this->client = $client;
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'is_running';
-    }
 }

--- a/src/Containers/StartupCheckStrategy/StartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/StartupCheckStrategy.php
@@ -15,11 +15,4 @@ interface StartupCheckStrategy
      * @return bool
      */
     public function waitUntilStartupSuccessful($containerId);
-
-    /**
-     * Get the name of the strategy.
-     *
-     * @return string The name of the strategy.
-     */
-    public function getName();
 }

--- a/src/Containers/StartupCheckStrategy/StartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/StartupCheckStrategy.php
@@ -2,6 +2,8 @@
 
 namespace Testcontainers\Containers\StartupCheckStrategy;
 
+use Testcontainers\Containers\ContainerInstance;
+
 /**
  * StartupCheckStrategy interface defines the contract for strategies that wait until a container startup is successful.
  * Implementations of this interface should provide the logic to determine when a container is fully operational.
@@ -11,8 +13,8 @@ interface StartupCheckStrategy
     /**
      * Wait until the container startup is successful
      *
-     * @param $containerId
+     * @param ContainerInstance $instance The container instance to check.
      * @return bool
      */
-    public function waitUntilStartupSuccessful($containerId);
+    public function waitUntilStartupSuccessful($instance);
 }

--- a/src/Containers/StartupCheckStrategy/StartupCheckStrategyProvider.php
+++ b/src/Containers/StartupCheckStrategy/StartupCheckStrategyProvider.php
@@ -16,16 +16,17 @@ class StartupCheckStrategyProvider
      *
      * This method adds a given wait strategy to the list of available strategies.
      *
+     * @param string $name The name of the wait strategy to register.
      * @param StartupCheckStrategy $strategy The wait strategy to register.
      *
      * @throws AlreadyExistsStartupStrategyException If a strategy with the same name already exists.
      */
-    public function register($strategy)
+    public function register($name, $strategy)
     {
-        if (isset($this->strategies[$strategy->getName()])) {
-            throw new AlreadyExistsStartupStrategyException($strategy->getName());
+        if (isset($this->strategies[$name])) {
+            throw new AlreadyExistsStartupStrategyException($name);
         }
-        $this->strategies[$strategy->getName()] = $strategy;
+        $this->strategies[$name] = $strategy;
     }
 
     /**

--- a/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
@@ -35,7 +35,7 @@ class StartupSettingTest extends TestCase
         $this->expectExceptionMessage('Illegal state of container');
 
         $container = (new StartupSettingWithStaticStartupCheckStrategyContainer('alpine:latest'))
-            ->withCommands(['echo', '1']);
+            ->withCommands(['sh', '-c', 'exit 1']);
         $container->start();
     }
 
@@ -56,7 +56,7 @@ class StartupSettingTest extends TestCase
 
         $container = (new GenericContainer('alpine:latest'))
             ->withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-            ->withCommands(['echo', '1']);
+            ->withCommands(['sh', '-c', 'exit 1']);
         $container->start();
     }
 }

--- a/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\StartupSetting;
+use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
+
+class StartupSettingTest extends TestCase
+{
+    public function testHasStartupSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(StartupSetting::class, $uses);
+    }
+
+    public function testStaticStartupTimeout()
+    {
+        $this->expectException(ProcessTimedOutException::class);
+
+        $container = (new StartupSettingWithStaticStartupTimeoutContainer('alpine:latest'))
+            ->withCommands(['sleep', '5']);
+        $container->start();
+    }
+
+    public function testStaticStartupCheckStrategy()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Illegal state of container');
+
+        $container = (new StartupSettingWithStaticStartupCheckStrategyContainer('alpine:latest'))
+            ->withCommands(['echo', '1']);
+        $container->start();
+    }
+
+    public function testStartWithStartupTimeout()
+    {
+        $this->expectException(ProcessTimedOutException::class);
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withStartupTimeout(1)
+            ->withCommands(['sleep', '5']);
+        $container->start();
+    }
+
+    public function testStartWithStartupCheckStrategy()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Illegal state of container');
+
+        $container = (new GenericContainer('alpine:latest'))
+            ->withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+            ->withCommands(['echo', '1']);
+        $container->start();
+    }
+}
+
+class StartupSettingWithStaticStartupTimeoutContainer extends GenericContainer
+{
+    protected static $STARTUP_TIMEOUT = 1;
+}
+
+class StartupSettingWithStaticStartupCheckStrategyContainer extends GenericContainer
+{
+    protected static $STARTUP_CHECK_STRATEGY = 'is_running';
+}

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -3,11 +3,8 @@
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\Exception\ProcessTimedOutException;
-use Testcontainers\Containers\BindMode;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
-use Testcontainers\Containers\ImagePullPolicy;
 use Testcontainers\Containers\PortStrategy\LocalRandomPortStrategy;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 use Testcontainers\Docker\DockerClientFactory;
@@ -99,16 +96,5 @@ class GenericContainerTest extends TestCase
         $this->assertTrue(is_int($instance->getMappedPort(443)));
         $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(443));
         $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
-    }
-
-    public function testStartWithStartupTimeout()
-    {
-        $this->expectException(ProcessTimedOutException::class);
-
-        $container = (new GenericContainer('alpine:latest'))
-            ->withStartupTimeout(1)
-            ->withCommands(['sleep', '5']);
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $container->start();
     }
 }

--- a/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyProviderTest.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers\StartupCheckStrategy;
 
 use PHPUnit\Framework\TestCase;
@@ -12,8 +14,7 @@ class StartupCheckStrategyProviderTest extends TestCase
     public function testRegister()
     {
         $provider = new StartupCheckStrategyProvider();
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new IsRunningStartupCheckStrategy());
+        $provider->register('is_running', new IsRunningStartupCheckStrategy());
 
         $this->assertTrue(true);
     }
@@ -24,17 +25,14 @@ class StartupCheckStrategyProviderTest extends TestCase
         $this->expectException(AlreadyExistsStartupStrategyException::class);
 
         $provider = new StartupCheckStrategyProvider();
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new IsRunningStartupCheckStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new IsRunningStartupCheckStrategy());
+        $provider->register('is_running', new IsRunningStartupCheckStrategy());
+        $provider->register('is_running', new IsRunningStartupCheckStrategy());
     }
 
     public function testGet()
     {
         $provider = new StartupCheckStrategyProvider();
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new IsRunningStartupCheckStrategy());
+        $provider->register('is_running', new IsRunningStartupCheckStrategy());
 
         $this->assertSame(IsRunningStartupCheckStrategy::class, get_class($provider->get('is_running')));
     }

--- a/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Containers\StartupCheckStrategy;
 
 use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategy;
 use Testcontainers\Docker\DockerClient;
 
@@ -21,8 +22,10 @@ abstract class StartupCheckStrategyTestCase extends TestCase
         $output = $client->run('alpine:latest', null, [], [
             'detach' => true,
         ]);
-        $containerId = $output->getContainerId();
+        $instance = new GenericContainerInstance([
+            'containerId' => $output->getContainerId(),
+        ]);
 
-        $this->assertTrue($strategy->waitUntilStartupSuccessful($containerId));
+        $this->assertTrue($strategy->waitUntilStartupSuccessful($instance));
     }
 }

--- a/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyTestCase.php
@@ -25,23 +25,4 @@ abstract class StartupCheckStrategyTestCase extends TestCase
 
         $this->assertTrue($strategy->waitUntilStartupSuccessful($containerId));
     }
-
-    public function testInterfaceGetName()
-    {
-        $strategy = $this->resolveStartupCheckStrategy();
-        $name = $strategy->getName();
-
-        $this->assertTrue(is_string($name));
-        $this->assertNotEmpty($name);
-        $this->assertTrue(preg_match('/^[a-z_][a-z0-9_]*$/', $name) === 1);
-    }
-
-    public function testInterfaceGetNameConsistency()
-    {
-        $strategy = $this->resolveStartupCheckStrategy();
-        $name1 = $strategy->getName();
-        $name2 = $strategy->getName();
-
-        $this->assertSame($name1, $name2);
-    }
 }


### PR DESCRIPTION
This pull request refactors the `GenericContainer` class to improve the handling of startup settings by introducing a new `StartupSetting` trait. It also modifies several related classes and updates the unit tests accordingly.

Refactoring and new functionality:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R41): Removed startup timeout and startup check strategy properties and methods, and added the `StartupSetting` trait. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R41) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L78-L107) Ffc99dcfL200R203, [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L263-L299)
* [`src/Containers/GenericContainer/StartupSetting.php`](diffhunk://#diff-4805eefa79619059aa7fb79b61330af24fac9407fd3cf0fd34f39a0db11718b2R1-R147): Introduced the `StartupSetting` trait to handle startup timeout and startup check strategy configuration and retrieval.

Updates to startup check strategy:

* [`src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php`](diffhunk://#diff-0ea982ceb5fe8735c26b86d88e8766c6d311eec67cc1d244ceec6d316a63375eL23-R28): Changed the `waitUntilStartupSuccessful` method to accept a `ContainerInstance` instead of a container ID, and removed the `getName` method. [[1]](diffhunk://#diff-0ea982ceb5fe8735c26b86d88e8766c6d311eec67cc1d244ceec6d316a63375eL23-R28) [[2]](diffhunk://#diff-0ea982ceb5fe8735c26b86d88e8766c6d311eec67cc1d244ceec6d316a63375eL55-L62)
* [`src/Containers/StartupCheckStrategy/StartupCheckStrategy.php`](diffhunk://#diff-731205e4105a114eb581911f40b86074ccac319968006846fa243a45b6527e7fL14-R19): Updated the `waitUntilStartupSuccessful` method to accept a `ContainerInstance` parameter.
* [`src/Containers/StartupCheckStrategy/StartupCheckStrategyProvider.php`](diffhunk://#diff-68f4c60260fbe611c31db18aba7646d42ca8d0e64202effe2d9792e1c1d7d4eeR19-R29): Modified the `register` method to accept a strategy name as a parameter.

Unit test updates:

* [`tests/Unit/Containers/GenericContainer/StartupSettingTest.php`](diffhunk://#diff-6ac9b9271dfa9ae607f0bad747456c08a45aaaac2593ebe0788c805e6a2baee8R1-R72): Added new tests for the `StartupSetting` trait.
* [`tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyProviderTest.php`](diffhunk://#diff-033cd643b3639414c2f2d40ce267e6a3b65b44a9f0b6dac31eaa706de4e78e0bL15-R17): Updated tests to reflect changes in the `register` method of `StartupCheckStrategyProvider`. [[1]](diffhunk://#diff-033cd643b3639414c2f2d40ce267e6a3b65b44a9f0b6dac31eaa706de4e78e0bL15-R17) [[2]](diffhunk://#diff-033cd643b3639414c2f2d40ce267e6a3b65b44a9f0b6dac31eaa706de4e78e0bL27-R35)

These changes streamline the configuration of startup settings and improve the flexibility and maintainability of the codebase.