### PR TITLE
Refactor wait strategy with WaitSetting trait and improve test coverage

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -79,9 +79,9 @@ class GenericContainer implements Container
         $this->image = $image ?: static::$IMAGE;
 
         $this->waitStrategyProvider = new WaitStrategyProvider();
-        $this->waitStrategyProvider->register(new HostPortWaitStrategy());
-        $this->waitStrategyProvider->register(new HttpWaitStrategy());
-        $this->waitStrategyProvider->register(new LogMessageWaitStrategy());
+        $this->waitStrategyProvider->register('host_port', new HostPortWaitStrategy());
+        $this->waitStrategyProvider->register('http', new HttpWaitStrategy());
+        $this->waitStrategyProvider->register('log', new LogMessageWaitStrategy());
         $this->registerWaitStrategy($this->waitStrategyProvider);
     }
 

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -5,11 +5,6 @@ namespace Testcontainers\Containers\GenericContainer;
 use LogicException;
 use RuntimeException;
 use Testcontainers\Containers\Container;
-use Testcontainers\Containers\WaitStrategy\AlreadyExistsWaitStrategyException;
-use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
-use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
-use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
-use Testcontainers\Containers\WaitStrategy\WaitStrategyProvider;
 use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\DockerClientFactory;
 use Testcontainers\Docker\Exception\BindAddressAlreadyUseException;
@@ -69,20 +64,12 @@ class GenericContainer implements Container
 
     /**
      * @param string|null $image The image to be used for the container.
-     *
-     * @throws AlreadyExistsWaitStrategyException if the wait strategy already exists.
      */
     public function __construct($image = null)
     {
         assert($image || static::$IMAGE);
 
         $this->image = $image ?: static::$IMAGE;
-
-        $this->waitStrategyProvider = new WaitStrategyProvider();
-        $this->waitStrategyProvider->register('host_port', new HostPortWaitStrategy());
-        $this->waitStrategyProvider->register('http', new HttpWaitStrategy());
-        $this->waitStrategyProvider->register('log', new LogMessageWaitStrategy());
-        $this->registerWaitStrategy($this->waitStrategyProvider);
     }
 
     /**

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -5,12 +5,10 @@ namespace Testcontainers\Containers\GenericContainer;
 use LogicException;
 use RuntimeException;
 use Testcontainers\Containers\Container;
-use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\WaitStrategy\AlreadyExistsWaitStrategyException;
 use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
 use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
-use Testcontainers\Containers\WaitStrategy\WaitStrategy;
 use Testcontainers\Containers\WaitStrategy\WaitStrategyProvider;
 use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\DockerClientFactory;
@@ -36,6 +34,7 @@ class GenericContainer implements Container
     use PullPolicySetting;
     use StartupSetting;
     use VolumesFromSetting;
+    use WaitSetting;
     use WorkdirSetting;
 
     /**
@@ -67,24 +66,6 @@ class GenericContainer implements Container
      * @var string[]
      */
     private $commands = [];
-
-    /**
-     * Define the default wait strategy to be used for the container.
-     * @var string|null
-     */
-    protected static $WAIT_STRATEGY;
-
-    /**
-     * The wait strategy to be used for the container.
-     * @var WaitStrategy|null
-     */
-    private $waitStrategy;
-
-    /**
-     * The wait strategy provider.
-     * @var WaitStrategyProvider
-     */
-    private $waitStrategyProvider;
 
     /**
      * @param string|null $image The image to be used for the container.
@@ -137,16 +118,6 @@ class GenericContainer implements Container
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function withWaitStrategy($waitStrategy)
-    {
-        $this->waitStrategy = $waitStrategy;
-
-        return $this;
-    }
-
-    /**
      * Retrieve the command to be executed in the container.
      *
      * This method returns the command that should be executed in the container.
@@ -164,41 +135,6 @@ class GenericContainer implements Container
             return $this->commands;
         }
         return null;
-    }
-
-    /**
-     * Retrieve the wait strategy for the container.
-     *
-     * This method returns the wait strategy that should be used for the container.
-     * If a specific wait strategy is set, it will return that. Otherwise, it will
-     * attempt to retrieve the default wait strategy from the provider.
-     *
-     * @param ContainerInstance $instance The container instance for which to get the wait strategy.
-     * @return WaitStrategy|null The wait strategy to be used, or null if none is set.
-     */
-    protected function waitStrategy(/** @noinspection PhpUnusedParameterInspection */ $instance)
-    {
-        if (static::$WAIT_STRATEGY !== null) {
-            $strategy = $this->waitStrategyProvider->get(static::$WAIT_STRATEGY);
-            if (!$strategy) {
-                throw new LogicException("Wait strategy not found: " . static::$WAIT_STRATEGY);
-            }
-            return $strategy;
-        }
-        if ($this->waitStrategy) {
-            return $this->waitStrategy;
-        }
-        return null;
-    }
-
-    /**
-     * Register a wait strategy.
-     *
-     * @param WaitStrategyProvider $provider The wait strategy provider.
-     */
-    protected function registerWaitStrategy($provider)
-    {
-        // Override this method to register custom wait strategies
     }
 
     /**

--- a/src/Containers/GenericContainer/WaitSetting.php
+++ b/src/Containers/GenericContainer/WaitSetting.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+use LogicException;
+use Testcontainers\Containers\ContainerInstance;
+use Testcontainers\Containers\WaitStrategy\WaitStrategy;
+use Testcontainers\Containers\WaitStrategy\WaitStrategyProvider;
+
+/**
+ * WaitSetting trait provides the functionality to set and retrieve the wait strategy for the container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$WAIT_STRATEGY`:
+ *
+ * <code>
+ *     class YourContainer extends GenericContainer
+ *     {
+ *         protected static $WAIT_STRATEGY = 'someWaitStrategy';
+ *     }
+ * </code>
+ *
+ * 2. method `withWaitStrategy`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *       ->withWaitStrategy(new SomeWaitStrategy());
+ * </code>
+ */
+trait WaitSetting
+{
+    /**
+     * Define the default wait strategy to be used for the container.
+     * @var string|null
+     */
+    protected static $WAIT_STRATEGY;
+
+    /**
+     * The wait strategy to be used for the container.
+     * @var WaitStrategy|null
+     */
+    private $waitStrategy;
+
+    /**
+     * The wait strategy provider.
+     * @var WaitStrategyProvider
+     */
+    private $waitStrategyProvider;
+
+    /**
+     * Set the wait strategy used for waiting for the container to start.
+     *
+     * @param WaitStrategy $waitStrategy The wait strategy to use.
+     * @return self
+     */
+    public function withWaitStrategy($waitStrategy)
+    {
+        $this->waitStrategy = $waitStrategy;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the wait strategy for the container.
+     *
+     * This method returns the wait strategy that should be used for the container.
+     * If a specific wait strategy is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default wait strategy from the provider.
+     *
+     * @param ContainerInstance $instance The container instance for which to get the wait strategy.
+     * @return WaitStrategy|null The wait strategy to be used, or null if none is set.
+     */
+    protected function waitStrategy(/** @noinspection PhpUnusedParameterInspection */ $instance)
+    {
+        if (static::$WAIT_STRATEGY !== null) {
+            $strategy = $this->waitStrategyProvider->get(static::$WAIT_STRATEGY);
+            if (!$strategy) {
+                throw new LogicException("Wait strategy not found: " . static::$WAIT_STRATEGY);
+            }
+            return $strategy;
+        }
+        if ($this->waitStrategy) {
+            return $this->waitStrategy;
+        }
+        return null;
+    }
+
+    /**
+     * Register a wait strategy.
+     *
+     * @param WaitStrategyProvider $provider The wait strategy provider.
+     */
+    protected function registerWaitStrategy($provider)
+    {
+        // Override this method to register custom wait strategies
+    }
+}

--- a/src/Containers/WaitStrategy/HostPortWaitStrategy.php
+++ b/src/Containers/WaitStrategy/HostPortWaitStrategy.php
@@ -91,12 +91,4 @@ class HostPortWaitStrategy implements WaitStrategy
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'host_port';
-    }
 }

--- a/src/Containers/WaitStrategy/HttpWaitStrategy.php
+++ b/src/Containers/WaitStrategy/HttpWaitStrategy.php
@@ -201,12 +201,4 @@ class HttpWaitStrategy implements WaitStrategy
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'http';
-    }
 }

--- a/src/Containers/WaitStrategy/LogMessageWaitStrategy.php
+++ b/src/Containers/WaitStrategy/LogMessageWaitStrategy.php
@@ -75,12 +75,4 @@ class LogMessageWaitStrategy implements WaitStrategy
 
         return $this;
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function getName()
-    {
-        return 'log_message';
-    }
 }

--- a/src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php
+++ b/src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php
@@ -181,12 +181,4 @@ class PDOConnectWaitStrategy implements WaitStrategy
         $this->retryInterval = $interval;
         return $this;
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function getName()
-    {
-        return 'pdo_connect';
-    }
 }

--- a/src/Containers/WaitStrategy/WaitStrategy.php
+++ b/src/Containers/WaitStrategy/WaitStrategy.php
@@ -11,16 +11,9 @@ use Testcontainers\Containers\ContainerInstance;
 interface WaitStrategy
 {
     /**
-    * Waits until the container instance is ready.
-    *
-    * @param ContainerInstance $instance The container instance to check.
-    */
-    public function waitUntilReady($instance);
-
-    /**
-     * Returns the name of the wait strategy.
+     * Waits until the container instance is ready.
      *
-     * @return string The name of the wait strategy.
+     * @param ContainerInstance $instance The container instance to check.
      */
-    public function getName();
+    public function waitUntilReady($instance);
 }

--- a/src/Containers/WaitStrategy/WaitStrategyProvider.php
+++ b/src/Containers/WaitStrategy/WaitStrategyProvider.php
@@ -23,16 +23,17 @@ class WaitStrategyProvider
      *
      * This method adds a given wait strategy to the list of available strategies.
      *
+     * @param string $name The name of the wait strategy to register.
      * @param WaitStrategy $strategy The wait strategy to register.
      *
      * @throws AlreadyExistsWaitStrategyException If a strategy with the same name already exists.
      */
-    public function register($strategy)
+    public function register($name, $strategy)
     {
-        if (isset($this->strategies[$strategy->getName()])) {
-            throw new AlreadyExistsWaitStrategyException($strategy->getName());
+        if (isset($this->strategies[$name])) {
+            throw new AlreadyExistsWaitStrategyException($name);
         }
-        $this->strategies[$strategy->getName()] = $strategy;
+        $this->strategies[$name] = $strategy;
     }
 
     /**

--- a/tests/Unit/Containers/GenericContainer/WaitSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/WaitSettingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\GenericContainer\WaitSetting;
+use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
+
+class WaitSettingTest extends TestCase
+{
+    public function testHasWaitSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(WaitSetting::class, $uses);
+    }
+
+    public function testStaticWaitStrategy()
+    {
+        $container = new WaitSettingWithStaticWaitStrategyContainer();
+        $container->start();
+
+        $this->assertTrue(true);
+    }
+
+    public function testStartWithWaitStrategy()
+    {
+        $container = (new GenericContainer('nginx:latest'))
+            ->withExposedPort(80)
+            ->withWaitStrategy(new HostPortWaitStrategy());
+        $container->start();
+
+        $this->assertTrue(true);
+    }
+}
+
+class WaitSettingWithStaticWaitStrategyContainer extends GenericContainer
+{
+    protected static $IMAGE = 'nginx:latest';
+
+    protected static $EXPOSED_PORTS = [80];
+
+    protected static $WAIT_STRATEGY = 'host_port';
+}

--- a/tests/Unit/Containers/PortStrategy/PortStrategyProviderTest.php
+++ b/tests/Unit/Containers/PortStrategy/PortStrategyProviderTest.php
@@ -54,11 +54,6 @@ class TestPortStrategy implements PortStrategy
         return 0;
     }
 
-    public function getName()
-    {
-        return 'test';
-    }
-
     public function conflictBehavior()
     {
         return ConflictBehavior::RETRY();

--- a/tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php
+++ b/tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers\WaitStrategy;
 
 use PHPUnit\Framework\TestCase;
@@ -12,8 +14,7 @@ class WaitStrategyProviderTest extends TestCase
     public function testRegister()
     {
         $provider = new WaitStrategyProvider();
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new TestWaitStrategy());
+        $provider->register('test', new TestWaitStrategy());
 
         $this->assertTrue(true);
     }
@@ -24,18 +25,15 @@ class WaitStrategyProviderTest extends TestCase
         $this->expectException(AlreadyExistsWaitStrategyException::class);
 
         $provider = new WaitStrategyProvider();
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new TestWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register(new TestWaitStrategy());
+        $provider->register('test', new TestWaitStrategy());
+        $provider->register('test', new TestWaitStrategy());
     }
 
     public function testGet()
     {
         $strategy = new TestWaitStrategy();
         $provider = new WaitStrategyProvider();
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $provider->register($strategy);
+        $provider->register('test', $strategy);
 
         $this->assertSame($strategy, $provider->get('test'));
     }
@@ -52,10 +50,5 @@ class TestWaitStrategy implements WaitStrategy
 {
     public function waitUntilReady($instance)
     {
-    }
-
-    public function getName()
-    {
-        return 'test';
     }
 }

--- a/tests/Unit/Containers/WaitStrategy/WaitStrategyTestCase.php
+++ b/tests/Unit/Containers/WaitStrategy/WaitStrategyTestCase.php
@@ -11,14 +11,4 @@ abstract class WaitStrategyTestCase extends TestCase
      * @return WaitStrategy
      */
     abstract public function resolveWaitStrategy();
-
-    public function testGetName()
-    {
-        $strategy = $this->resolveWaitStrategy();
-        $name = $strategy->getName();
-
-        $this->assertTrue(is_string($name));
-        $this->assertNotEmpty($name);
-        $this->assertTrue(preg_match('/^[a-z_][a-z0-9_]*$/', $name) === 1);
-    }
 }


### PR DESCRIPTION
This pull request refactors the wait strategy implementation in the `GenericContainer` class by introducing a new `WaitSetting` trait and removing redundant methods. It also updates the related unit tests to reflect these changes.

### Refactoring of Wait Strategy Implementation:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L8-L14): Removed the wait strategy properties and methods, and added the `WaitSetting` trait to handle wait strategy functionalities. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L8-L14) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R32) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L71-L104) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L139-L148) [[5]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L169-L203)

* [`src/Containers/GenericContainer/WaitSetting.php`](diffhunk://#diff-63ed0bde17f78e564d89149d60365d39f676059a53d3d9e1002338d2f66f5056R1-R111): Introduced a new `WaitSetting` trait that provides methods to set and retrieve the wait strategy for the container.

### Simplification and Cleanup:

* `src/Containers/WaitStrategy/HostPortWaitStrategy.php`, `src/Containers/WaitStrategy/HttpWaitStrategy.php`, `src/Containers/WaitStrategy/LogMessageWaitStrategy.php`, `src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php`, `src/Containers/WaitStrategy/WaitStrategy.php`: Removed the `getName` method from various wait strategy classes and the `WaitStrategy` interface. [[1]](diffhunk://#diff-f7aa1e5500d7cfed38fcc39dc5e567fddc68c33359c215dab4fbc5ae4bb541e7L94-L101) [[2]](diffhunk://#diff-e82e53f4f7540d6e7e0daee75c4b9045e11ac60df33b97aa443f8fd8854d1a79L204-L211) [[3]](diffhunk://#diff-831109cba2317c2ef31a817cd4dfc9c55d2908cbcc239b62dc0927122abcb460L78-L85) [[4]](diffhunk://#diff-420b2650993895bb388a5fce781151becb40eef80df780381fb292ee631a3c90L184-L191) [[5]](diffhunk://#diff-5c52f92afc80805f7eec6ecc38d81de9fbbc70c798f6bef37d0612e31905cf29L19-L25)

* [`src/Containers/WaitStrategy/WaitStrategyProvider.php`](diffhunk://#diff-d42e96b08793864de73eca923220176ec2d036d02087f414a632d98f6bfb3842R26-R36): Updated the `register` method to accept a name parameter instead of using the `getName` method from the strategy.

### Unit Test Updates:

* [`tests/Unit/Containers/GenericContainer/WaitSettingTest.php`](diffhunk://#diff-c0ae47508a67e669fb15e5da3f8afff1ad2e7e906736c4a870ce418a1a0fa2adR1-R47): Added new unit tests for the `WaitSetting` trait to ensure correct functionality.

* [`tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php`](diffhunk://#diff-270546e0d9507c9a69ba55e4f889323046a6b30d59e0f5ead60a30a00dec3a8cR3-R4): Updated the unit tests to reflect the changes in the `register` method of `WaitStrategyProvider`. [[1]](diffhunk://#diff-270546e0d9507c9a69ba55e4f889323046a6b30d59e0f5ead60a30a00dec3a8cR3-R4) [[2]](diffhunk://#diff-270546e0d9507c9a69ba55e4f889323046a6b30d59e0f5ead60a30a00dec3a8cL15-R17) [[3]](diffhunk://#diff-270546e0d9507c9a69ba55e4f889323046a6b30d59e0f5ead60a30a00dec3a8cL27-R36) [[4]](diffhunk://#diff-270546e0d9507c9a69ba55e4f889323046a6b30d59e0f5ead60a30a00dec3a8cL56-L60)

* [`tests/Unit/Containers/WaitStrategy/WaitStrategyTestCase.php`](diffhunk://#diff-67ded8d5bf4d2bb4c2f95bda05f665466cd236accd267ef53499fe885123eb35L14-L23): Removed the test for the `getName` method.