### PR TITLE
Refactor GenericContainer with enhanced GeneralSetting trait

### DIFF
--- a/src/Containers/GenericContainer/GeneralSetting.php
+++ b/src/Containers/GenericContainer/GeneralSetting.php
@@ -39,6 +39,18 @@ trait GeneralSetting
     private $image;
 
     /**
+     * The commands to be executed in the container.
+     * @var null|string|string[]
+     */
+    protected static $COMMANDS;
+
+    /**
+     * The commands to be executed in the container.
+     * @var string[]
+     */
+    private $commands = [];
+
+    /**
      * Define the default name to be used for the container.
      * @var string|null
      */
@@ -49,6 +61,26 @@ trait GeneralSetting
      * @var string|null
      */
     private $name;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withCommand($cmd)
+    {
+        $this->commands = [$cmd];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withCommands($commandParts)
+    {
+        $this->commands = $commandParts;
+
+        return $this;
+    }
 
     /**
      * Set the name for this container, similar to the `--name <name>` option on the Docker CLI.
@@ -71,6 +103,60 @@ trait GeneralSetting
     public function image()
     {
         return $this->image;
+    }
+
+    /**
+     * Retrieve the command to be executed in the container.
+     *
+     * This method returns the command that should be executed in the container.
+     * If a specific command is set, it will return that. Otherwise, it will
+     * attempt to retrieve the default command from the provider.
+     *
+     * @return string|string[]|null
+     */
+    protected function commands()
+    {
+        if (static::$COMMANDS) {
+            return static::$COMMANDS;
+        }
+        if ($this->commands) {
+            return $this->commands;
+        }
+        return null;
+    }
+
+    /**
+     * Retrieve the command to be executed
+     *
+     * @return string|null
+     */
+    protected function command()
+    {
+        $commands = $this->commands();
+        if (is_string($commands)) {
+            $commands = [$commands];
+        }
+        if (is_array($commands) && count($commands) > 0) {
+            return $commands[0];
+        }
+        return null;
+    }
+
+    /**
+     * Retrieve the arguments to be passed to the command
+     *
+     * @return string[]
+     */
+    protected function args()
+    {
+        $commands = $this->commands();
+        if (is_string($commands)) {
+            $commands = [$commands];
+        }
+        if (is_array($commands) && count($commands) > 1) {
+            return array_slice($commands, 1);
+        }
+        return [];
     }
 
     /**

--- a/src/Containers/GenericContainer/GeneralSetting.php
+++ b/src/Containers/GenericContainer/GeneralSetting.php
@@ -6,11 +6,13 @@ namespace Testcontainers\Containers\GenericContainer;
  * GeneralSetting is a trait that provides the ability to set the name for a container.
  *
  * Two formats are supported:
- * 1. static variable `$NAME`:
+ * 1. static variable `$IMAGE` and `$NAME`:
  *
  * <code>
  * class YourContainer extends GenericContainer
  * {
+ *     protected static $IMAGE = 'image';
+ *
  *     protected static $NAME = 'your-container';
  * }
  * </code>
@@ -24,6 +26,18 @@ namespace Testcontainers\Containers\GenericContainer;
  */
 trait GeneralSetting
 {
+    /**
+     * Define the default image to be used for the container.
+     * @var string|null
+     */
+    protected static $IMAGE;
+
+    /**
+     * The image to be used for the container.
+     * @var string
+     */
+    private $image;
+
     /**
      * Define the default name to be used for the container.
      * @var string|null
@@ -47,6 +61,16 @@ trait GeneralSetting
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * Retrieve the image to be used for the container.
+     *
+     * @return string
+     */
+    public function image()
+    {
+        return $this->image;
     }
 
     /**

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -39,18 +39,6 @@ class GenericContainer implements Container
     private $client;
 
     /**
-     * Define the default image to be used for the container.
-     * @var string|null
-     */
-    protected static $IMAGE;
-
-    /**
-     * The image to be used for the container.
-     * @var string
-     */
-    private $image;
-
-    /**
      * The commands to be executed in the container.
      * @var null|string|string[]
      */
@@ -176,9 +164,9 @@ class GenericContainer implements Container
             ];
             $timeout = $this->startupTimeout();
             if ($timeout !== null) {
-                $output = $client->withTimeout($timeout)->run($this->image, $command, $args, $options);
+                $output = $client->withTimeout($timeout)->run($this->image(), $command, $args, $options);
             } else {
-                $output = $client->run($this->image, $command, $args, $options);
+                $output = $client->run($this->image(), $command, $args, $options);
             }
         } catch (PortAlreadyAllocatedException $e) {
             if ($portStrategy === null) {

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -39,18 +39,6 @@ class GenericContainer implements Container
     private $client;
 
     /**
-     * The commands to be executed in the container.
-     * @var null|string|string[]
-     */
-    protected static $COMMANDS;
-
-    /**
-     * The commands to be executed in the container.
-     * @var string[]
-     */
-    private $commands = [];
-
-    /**
      * @param string|null $image The image to be used for the container.
      */
     public function __construct($image = null)
@@ -74,64 +62,11 @@ class GenericContainer implements Container
 
     /**
      * {@inheritdoc}
-     */
-    public function withCommand($cmd)
-    {
-        $this->commands = [$cmd];
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withCommands($commandParts)
-    {
-        $this->commands = $commandParts;
-
-        return $this;
-    }
-
-    /**
-     * Retrieve the command to be executed in the container.
-     *
-     * This method returns the command that should be executed in the container.
-     * If a specific command is set, it will return that. Otherwise, it will
-     * attempt to retrieve the default command from the provider.
-     *
-     * @return string|string[]|null
-     */
-    protected function commands()
-    {
-        if (static::$COMMANDS) {
-            return static::$COMMANDS;
-        }
-        if ($this->commands) {
-            return $this->commands;
-        }
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
      *
      * @throws InvalidFormatException If the provided mode is not valid.
      */
     public function start()
     {
-        $commands = $this->commands();
-        if (is_string($commands)) {
-            $commands = [$commands];
-        }
-        $command = null;
-        $args = [];
-        if (is_array($commands)) {
-            $command = $commands[0];
-            if (count($commands) > 1) {
-                $args = array_slice($commands, 1);
-            }
-        }
-
         $extraHosts = $this->extraHosts();
         $hosts = [];
         if ($extraHosts) {
@@ -164,9 +99,9 @@ class GenericContainer implements Container
             ];
             $timeout = $this->startupTimeout();
             if ($timeout !== null) {
-                $output = $client->withTimeout($timeout)->run($this->image(), $command, $args, $options);
+                $output = $client->withTimeout($timeout)->run($this->image(), $this->command(), $this->args(), $options);
             } else {
-                $output = $client->run($this->image(), $command, $args, $options);
+                $output = $client->run($this->image(), $this->command(), $this->args(), $options);
             }
         } catch (PortAlreadyAllocatedException $e) {
             if ($portStrategy === null) {


### PR DESCRIPTION
This pull request introduces significant changes to the `GenericContainer` class and the `GeneralSetting` trait to enhance the handling of container images and commands. The most important changes include adding new properties and methods to the `GeneralSetting` trait and refactoring the `GenericContainer` class to utilize these new methods.

Enhancements to `GeneralSetting` trait:

* Added new properties `protected static $IMAGE`, `private $image`, `protected static $COMMANDS`, and `private $commands` to handle container images and commands.
* Introduced new methods `withCommand($cmd)`, `withCommands($commandParts)`, `image()`, `commands()`, `command()`, and `args()` to manage and retrieve container commands and arguments. [[1]](diffhunk://#diff-cb2635aa413e9c1f85bab32bc18526ad3584b3c960eeaaa7e9391e5ba382683dR65-R84) [[2]](diffhunk://#diff-cb2635aa413e9c1f85bab32bc18526ad3584b3c960eeaaa7e9391e5ba382683dR98-R161)

Refactoring of `GenericContainer` class:

* Removed redundant properties and methods related to container images and commands, which are now handled by the `GeneralSetting` trait. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L41-L64) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L87-L146)
* Updated the `start()` method to use the new `image()`, `command()`, and `args()` methods from the `GeneralSetting` trait for improved command execution.