### PR TITLE
Refactor GenericContainer with enhanced error handling and expanded tests

### DIFF
--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -98,7 +98,6 @@ class GenericContainer implements Container
         ];
         $timeout = $this->startupTimeout();
 
-
         try {
             if ($timeout !== null) {
                 $output = $client->withTimeout($timeout)->run($image, $command, $args, $options);

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -8,6 +8,9 @@ use Testcontainers\Containers\Container;
 use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\DockerClientFactory;
 use Testcontainers\Docker\Exception\BindAddressAlreadyUseException;
+use Testcontainers\Docker\Exception\DockerException;
+use Testcontainers\Docker\Exception\NoSuchContainerException;
+use Testcontainers\Docker\Exception\NoSuchObjectException;
 use Testcontainers\Docker\Output\DockerRunWithDetachOutput;
 use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
 use Testcontainers\Exceptions\InvalidFormatException;
@@ -64,6 +67,7 @@ class GenericContainer implements Container
      * {@inheritdoc}
      *
      * @throws InvalidFormatException If the provided mode is not valid.
+     * @throws DockerException If the Docker command fails.
      */
     public function start()
     {
@@ -128,9 +132,6 @@ class GenericContainer implements Container
         }
         if (!($output instanceof DockerRunWithDetachOutput)) {
             throw new LogicException('Expected DockerRunWithDetachOutput');
-        }
-        if ($output->getExitCode() !== 0) {
-            throw new RuntimeException('Failed to start container');
         }
         $containerDef = [
             'containerId' => $output->getContainerId(),

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -143,7 +143,7 @@ class GenericContainer implements Container
         $instance = new GenericContainerInstance($containerDef);
         $instance->setDockerClient($client);
 
-        $startupCheckStrategy = $this->startupCheckStrategy();
+        $startupCheckStrategy = $this->startupCheckStrategy($instance);
         if ($startupCheckStrategy) {
             if ($startupCheckStrategy->waitUntilStartupSuccessful($instance) === false) {
                 throw new RuntimeException('Illegal state of container');

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -67,21 +67,13 @@ class GenericContainer implements Container
      */
     public function start()
     {
-        $extraHosts = $this->extraHosts();
-        $hosts = [];
-        if ($extraHosts) {
-            foreach ($extraHosts as $host) {
-                $hosts[] = $host->toString();
-            }
-        }
-
         $portStrategy = $this->portStrategy();
         $ports = $this->ports();
         $client = $this->client ?: DockerClientFactory::create();
 
         try {
             $options = [
-                'addHost' => $hosts,
+                'addHost' => $this->extraHosts(),
                 'detach' => true,
                 'env' => $this->env(),
                 'label' => $this->labels(),

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -104,6 +104,9 @@ class GenericContainer implements Container
             } else {
                 $output = $client->run($image, $command, $args, $options);
             }
+            if (!($output instanceof DockerRunWithDetachOutput)) {
+                throw new LogicException('Expected DockerRunWithDetachOutput');
+            }
         } catch (PortAlreadyAllocatedException $e) {
             if ($portStrategy === null) {
                 throw $e;
@@ -129,9 +132,7 @@ class GenericContainer implements Container
             }
             throw new LogicException('Unknown conflict behavior: `' . $behavior . '`', 0, $e);
         }
-        if (!($output instanceof DockerRunWithDetachOutput)) {
-            throw new LogicException('Expected DockerRunWithDetachOutput');
-        }
+
         $containerDef = [
             'containerId' => $output->getContainerId(),
             'labels' => $this->labels(),
@@ -145,7 +146,7 @@ class GenericContainer implements Container
         $startupCheckStrategy = $this->startupCheckStrategy($instance);
         if ($startupCheckStrategy) {
             if ($startupCheckStrategy->waitUntilStartupSuccessful($instance) === false) {
-                throw new RuntimeException('Illegal state of container');
+                throw new RuntimeException('failed startup check: illegal state of container');
             }
         }
 

--- a/src/Containers/GenericContainer/NetworkModeSetting.php
+++ b/src/Containers/GenericContainer/NetworkModeSetting.php
@@ -4,6 +4,26 @@ namespace Testcontainers\Containers\GenericContainer;
 
 use Testcontainers\Containers\Types\NetworkMode;
 
+/**
+ * NetworkModeSetting is a trait that provides the ability to set the network mode for a container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$NETWORK_MODE`:
+ *
+ * <code>
+ *     class YourContainer extends GenericContainer
+ *     {
+ *         protected static $NETWORK_MODE = 'host';
+ *     }
+ * </code>
+ *
+ * 2. method `withNetworkMode`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *         ->withNetworkMode('host');
+ * </code>
+ */
 trait NetworkModeSetting
 {
     /**

--- a/src/Containers/GenericContainer/StartupSetting.php
+++ b/src/Containers/GenericContainer/StartupSetting.php
@@ -3,6 +3,7 @@
 namespace Testcontainers\Containers\GenericContainer;
 
 use LogicException;
+use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\StartupCheckStrategy\AlreadyExistsStartupStrategyException;
 use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
 use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategy;
@@ -109,9 +110,10 @@ trait StartupSetting
      * If a specific startup check strategy is set, it will return that. Otherwise, it will
      * attempt to retrieve the default startup check strategy from the provider.
      *
+     * @param ContainerInstance $instance The container instance for which to get the startup check strategy.
      * @return StartupCheckStrategy|null The startup check strategy to be used, or null if none is set.
      */
-    protected function startupCheckStrategy()
+    protected function startupCheckStrategy(/** @noinspection PhpUnusedParameterInspection */ $instance)
     {
         if ($this->startupCheckStrategyProvider === null) {
             $this->startupCheckStrategyProvider = new StartupCheckStrategyProvider();

--- a/src/Containers/Types/Mount.php
+++ b/src/Containers/Types/Mount.php
@@ -103,8 +103,6 @@ class Mount
      *
      * @param string $v The volume string.
      * @return Mount The Mount object.
-     *
-     * @throws InvalidFormatException If the format is invalid.
      */
     public static function fromVolumeString($v)
     {

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -216,6 +216,7 @@ trait BaseCommand
      * @throws NoSuchContainerException If the specified container does not exist.
      * @throws NoSuchObjectException If the specified object does not exist.
      * @throws PortAlreadyAllocatedException If the specified port is already allocated.
+     * @throws BindAddressAlreadyUseException If the specified bind address is already in use.
      * @throws DockerException If the Docker command fails.
      */
     protected function execute($command, $subcommand = null, $args = [], $options = [], $wait = true)

--- a/src/Docker/Command/RunCommand.php
+++ b/src/Docker/Command/RunCommand.php
@@ -2,6 +2,9 @@
 
 namespace Testcontainers\Docker\Command;
 
+use Testcontainers\Docker\Exception\BindAddressAlreadyUseException;
+use Testcontainers\Docker\Exception\NoSuchContainerException;
+use Testcontainers\Docker\Exception\NoSuchObjectException;
 use Testcontainers\Docker\Output\DockerRunOutput;
 use Testcontainers\Docker\Output\DockerRunWithDetachOutput;
 use Testcontainers\Docker\Exception\DockerException;
@@ -39,7 +42,10 @@ trait RunCommand
      * } $options Additional options for the Docker command.
      * @return DockerRunOutput|DockerRunWithDetachOutput The output of the Docker run command. If the `detach` option is set to `true`, a `DockerRunWithDetachOutput` object is returned.
      *
+     * @throws NoSuchContainerException If the specified container does not exist.
+     * @throws NoSuchObjectException If the specified object does not exist.
      * @throws PortAlreadyAllocatedException If the specified port is already allocated.
+     * @throws BindAddressAlreadyUseException If the specified bind address is already in use.
      * @throws DockerException If the Docker command fails.
      */
     public function run($image, $command = null, $args = [], $options = [])

--- a/tests/Unit/Containers/BindModeTest.php
+++ b/tests/Unit/Containers/BindModeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
@@ -38,7 +40,6 @@ class BindModeTest extends TestCase
 
     public function testFromStringWithReadOnly()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $bindMode = BindMode::fromString(BindMode::$READ_ONLY);
 
         $this->assertSame(BindMode::$READ_ONLY, $bindMode->toString());
@@ -46,7 +47,6 @@ class BindModeTest extends TestCase
 
     public function testFromStringWithReadWrite()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $bindMode = BindMode::fromString(BindMode::$READ_WRITE);
 
         $this->assertSame(BindMode::$READ_WRITE, $bindMode->toString());
@@ -57,7 +57,6 @@ class BindModeTest extends TestCase
         $this->expectException(InvalidFormatException::class);
         $this->expectExceptionMessage('Invalid format: `"invalid"`, expects: `ro`, `rw`');
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         BindMode::fromString('invalid');
     }
 

--- a/tests/Unit/Containers/GenericContainer/GeneralSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/GeneralSettingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Tests\Unit\Containers\GenericContainer;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GeneralSetting;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
+
+class GeneralSettingTest extends TestCase
+{
+    public function testHasGeneralSettingTrait()
+    {
+        $uses = class_uses(GenericContainer::class);
+
+        $this->assertContains(GeneralSetting::class, $uses);
+    }
+
+    public function testStaticCommands()
+    {
+        $container = new GeneralSettingWithStaticCommandsContainer('alpine:latest');
+        $instance = $container->start();
+
+        $this->assertSame("Hello, World!\n", $instance->getOutput());
+    }
+
+    public function testStartWithCommand()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withCommand('pwd');
+        $instance = $container->start();
+
+        $this->assertSame("/\n", $instance->getOutput());
+    }
+
+    public function testStartWithCommands()
+    {
+        $container = (new GenericContainer('alpine:latest'))
+            ->withCommands(['echo', 'Hello, World!'])
+            ->withWaitStrategy(new LogMessageWaitStrategy());
+        $instance = $container->start();
+
+        $this->assertSame("Hello, World!\n", $instance->getOutput());
+    }
+}
+
+class GeneralSettingWithStaticCommandsContainer extends GenericContainer
+{
+    protected static $COMMANDS = ['echo', 'Hello, World!'];
+}

--- a/tests/Unit/Containers/GenericContainer/LabelSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/LabelSettingTest.php
@@ -11,7 +11,7 @@ use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
 class LabelSettingTest extends TestCase
 {
-    public function testHasEnvSettingTrait()
+    public function testHasLabelSettingTrait()
     {
         $uses = class_uses(GenericContainer::class);
 
@@ -33,7 +33,6 @@ class LabelSettingTest extends TestCase
             ->withLabel('KEY1', 'VALUE1')
             ->withLabel('KEY2', 'VALUE2')
             ->withWaitStrategy(new LogMessageWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("VALUE1", $instance->getLabel('KEY1'));
@@ -46,7 +45,6 @@ class LabelSettingTest extends TestCase
         $container = (new GenericContainer('alpine:latest'))
             ->withLabels(['KEY1' => 'VALUE1', 'KEY2' => 'VALUE2'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("VALUE1", $instance->getLabel('KEY1'));

--- a/tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php
@@ -29,7 +29,6 @@ class PrivilegeSettingTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withPrivilegedMode(true);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame(true, $instance->getPrivilegedMode());

--- a/tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php
@@ -30,7 +30,6 @@ class PullPolicySettingTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withImagePullPolicy(ImagePullPolicy::MISSING());
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame(ImagePullPolicy::$MISSING, $instance->getImagePullPolicy()->toString());

--- a/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
@@ -32,7 +32,7 @@ class StartupSettingTest extends TestCase
     public function testStaticStartupCheckStrategy()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Illegal state of container');
+        $this->expectExceptionMessage('failed startup check: illegal state of container');
 
         $container = (new StartupSettingWithStaticStartupCheckStrategyContainer('alpine:latest'))
             ->withCommands(['sh', '-c', 'exit 1']);
@@ -52,7 +52,7 @@ class StartupSettingTest extends TestCase
     public function testStartWithStartupCheckStrategy()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Illegal state of container');
+        $this->expectExceptionMessage('failed startup check: illegal state of container');
 
         $container = (new GenericContainer('alpine:latest'))
             ->withStartupCheckStrategy(new IsRunningStartupCheckStrategy())

--- a/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
@@ -15,7 +15,7 @@ use Tests\Images\DinD;
 
 class VolumesFromSettingTest extends TestCase
 {
-    public function testHasNetworkModeSettingTrait()
+    public function testHasVolumesFromSettingTrait()
     {
         $uses = class_uses(GenericContainer::class);
 

--- a/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
@@ -43,6 +43,7 @@ class VolumesFromSettingTest extends TestCase
             ->withDockerClient($client)
             ->withName('volumes-from-container')
             ->withFileSystemBind($path, $path, BindMode::READ_WRITE());
+        /** @noinspection PhpUnusedLocalVariableInspection */
         $instance1 = $container->start();
 
         $container = (new VolumesFromSettingWithStaticVolumesFromContainer('alpine:latest'))

--- a/tests/Unit/Containers/GenericContainer/WorkdirSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/WorkdirSettingTest.php
@@ -34,7 +34,6 @@ class WorkdirSettingTest extends TestCase
             ->withWorkingDirectory('/tmp')
             ->withCommands(['pwd'])
             ->withWaitStrategy(new LogMessageWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertSame("/tmp\n", $instance->getOutput());

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
@@ -89,7 +91,6 @@ class GenericContainerInstanceTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withCommands(['echo', 'Hello, World!']);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         while ($instance->isRunning()) {
@@ -103,7 +104,6 @@ class GenericContainerInstanceTest extends TestCase
     {
         $container = (new GenericContainer('alpine:latest'))
             ->withCommands(['ls', '/not-exist-dir']);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         while ($instance->isRunning()) {

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -1,100 +1,21 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
-use Testcontainers\Containers\PortStrategy\RandomPortStrategy;
-use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
-use Testcontainers\Docker\DockerClientFactory;
-use Testcontainers\Testcontainers;
-use Tests\Images\DinD;
 
 class GenericContainerTest extends TestCase
 {
     public function testStart()
     {
         $container = new GenericContainer('alpine:latest');
-        /** @noinspection PhpUnhandledExceptionInspection */
         $instance = $container->start();
 
         $this->assertInstanceOf(ContainerInstance::class, $instance);
         $this->assertNotEmpty($instance->getContainerId());
-    }
-
-    public function testStartWithCommand()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withCommand('pwd');
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertSame("/\n", $instance->getOutput());
-    }
-
-    public function testStartWithCommands()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withCommands(['echo', 'Hello, World!'])
-            ->withWaitStrategy(new LogMessageWaitStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertSame("Hello, World!\n", $instance->getOutput());
-    }
-
-    public function testStartWithNetworkAliases()
-    {
-        $instance = Testcontainers::run(DinD::class);
-
-        $client = DockerClientFactory::create([
-            'globalOptions' => [
-                'host' => 'tcp://' . $instance->getHost() . ':' . $instance->getMappedPort(2375)
-            ],
-        ]);
-        $network = md5(uniqid());
-        $client->networkCreate($network);
-
-        $container = (new GenericContainer('alpine:latest'))
-            ->withDockerClient($client)
-            ->withNetworkMode($network)
-            ->withNetworkAliases(['my-alias'])
-            ->withCommands(['sh', '-c', 'ping -c 1 my-alias']);
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertStringStartsWith('PING my-alias', $instance->getOutput());
-    }
-
-    public function testStartWithExposedPorts()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withExposedPorts(80)
-            ->withPortStrategy(new RandomPortStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertInstanceOf(ContainerInstance::class, $instance);
-        $this->assertTrue(is_int($instance->getMappedPort(80)));
-        $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(80));
-        $this->assertLessThanOrEqual(65535, $instance->getMappedPort(80));
-    }
-
-    public function testStartWithExposedPortsMultiple()
-    {
-        $container = (new GenericContainer('alpine:latest'))
-            ->withExposedPorts([80, 443])
-            ->withPortStrategy(new RandomPortStrategy());
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $instance = $container->start();
-
-        $this->assertInstanceOf(ContainerInstance::class, $instance);
-        $this->assertTrue(is_int($instance->getMappedPort(80)));
-        $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(80));
-        $this->assertLessThanOrEqual(65535, $instance->getMappedPort(80));
-        $this->assertTrue(is_int($instance->getMappedPort(443)));
-        $this->assertGreaterThanOrEqual(49152, $instance->getMappedPort(443));
-        $this->assertLessThanOrEqual(65535, $instance->getMappedPort(443));
     }
 }

--- a/tests/Unit/Containers/ImagePullPolicyTest.php
+++ b/tests/Unit/Containers/ImagePullPolicyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers;
 
 use PHPUnit\Framework\TestCase;
@@ -52,7 +54,6 @@ class ImagePullPolicyTest extends TestCase
 
     public function testFromStringWithAlways()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $imagePullPolicy = ImagePullPolicy::fromString(ImagePullPolicy::$ALWAYS);
 
         $this->assertSame(ImagePullPolicy::$ALWAYS, $imagePullPolicy->toString());
@@ -60,7 +61,6 @@ class ImagePullPolicyTest extends TestCase
 
     public function testFromStringWithMissing()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $imagePullPolicy = ImagePullPolicy::fromString(ImagePullPolicy::$MISSING);
 
         $this->assertSame(ImagePullPolicy::$MISSING, $imagePullPolicy->toString());
@@ -68,7 +68,6 @@ class ImagePullPolicyTest extends TestCase
 
     public function testFromStringWithNever()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $imagePullPolicy = ImagePullPolicy::fromString(ImagePullPolicy::$NEVER);
 
         $this->assertSame(ImagePullPolicy::$NEVER, $imagePullPolicy->toString());
@@ -78,7 +77,6 @@ class ImagePullPolicyTest extends TestCase
     {
         $this->expectException(InvalidFormatException::class);
         $this->expectExceptionMessage('Invalid format: `"invalid"`, expects: `always`, `missing`, `never`');
-        /** @noinspection PhpUnhandledExceptionInspection */
         ImagePullPolicy::fromString('invalid');
     }
 

--- a/tests/Unit/Containers/PortStrategy/ConflictBehaviorTest.php
+++ b/tests/Unit/Containers/PortStrategy/ConflictBehaviorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers\PortStrategy;
 
 use PHPUnit\Framework\TestCase;
@@ -38,7 +40,6 @@ class ConflictBehaviorTest extends TestCase
 
     public function testFromStringWithRetry()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $conflictBehavior = ConflictBehavior::fromString(ConflictBehavior::$RETRY);
 
         $this->assertSame(ConflictBehavior::$RETRY, $conflictBehavior->toString());
@@ -46,7 +47,6 @@ class ConflictBehaviorTest extends TestCase
 
     public function testFromStringWithFail()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $conflictBehavior = ConflictBehavior::fromString(ConflictBehavior::$FAIL);
 
         $this->assertSame(ConflictBehavior::$FAIL, $conflictBehavior->toString());
@@ -57,7 +57,6 @@ class ConflictBehaviorTest extends TestCase
         $this->expectException(InvalidFormatException::class);
         $this->expectExceptionMessage('Invalid format: `"invalid"`, expects: `retry`, `fail`');
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         ConflictBehavior::fromString('invalid');
     }
 

--- a/tests/Unit/Containers/Types/HostToIpTest.php
+++ b/tests/Unit/Containers/Types/HostToIpTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers\Types;
 
 use PHPUnit\Framework\TestCase;
@@ -18,7 +20,6 @@ class HostToIpTest extends TestCase
 
     public function testFromString()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $value = HostToIp::fromString('docker.internal:127.0.0.1');
 
         $this->assertSame('docker.internal', $value->host);
@@ -30,13 +31,11 @@ class HostToIpTest extends TestCase
         $this->expectExceptionMessage('Invalid format: `"docker.internal"`, expects: `host:ip`');
         $this->expectException(InvalidFormatException::class);
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         HostToIp::fromString('docker.internal');
     }
 
     public function testFromArray()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $value = HostToIp::fromArray(['hostname' => 'docker.internal', 'ipAddress' => '127.0.0.1']);
 
         $this->assertSame('docker.internal', $value->host);
@@ -48,7 +47,6 @@ class HostToIpTest extends TestCase
         $this->expectExceptionMessage('Invalid format: `[]`, expects: `["hostname": string, "ipAddress": string]`');
         $this->expectException(InvalidFormatException::class);
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         HostToIp::fromArray([]);
     }
 

--- a/tests/Unit/Containers/Types/MountTest.php
+++ b/tests/Unit/Containers/Types/MountTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Tests\Unit\Containers\Types;
 
 use PHPUnit\Framework\TestCase;
@@ -30,7 +32,6 @@ class MountTest extends TestCase
 
     public function testFromStringParsesTargetOnlyBindMountString()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $mount = Mount::fromString('/container/path');
 
         $this->assertSame('bind', $mount->type);
@@ -44,7 +45,6 @@ class MountTest extends TestCase
 
     public function testFromStringParsesCompleteBindMountString()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $mount = Mount::fromString('/host/path:/container/path:ro');
 
         $this->assertSame('bind', $mount->type);
@@ -58,7 +58,6 @@ class MountTest extends TestCase
 
     public function testFromStringParsesTargetOnlyMountString()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $mount = Mount::fromString('target=/container/path');
 
         $this->assertSame('bind', $mount->type);
@@ -72,7 +71,6 @@ class MountTest extends TestCase
 
     public function testFromStringParsesCompleteMountString()
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $mount = Mount::fromString('type=volume,source=/host/path,destination=/container/path,volume-subpath=/sub/path,readonly,volume-nocopy');
 
         $this->assertSame('volume', $mount->type);


### PR DESCRIPTION
This pull request includes several changes to improve error handling, add documentation, and update test cases in the Testcontainers library. The most important changes include adding new exception classes, updating method signatures to include new exceptions, and adding documentation to various traits.

### Improvements to error handling:

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R11-R13): Added new exception classes `DockerException`, `NoSuchContainerException`, and `NoSuchObjectException` to improve error handling in the `start` method. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R11-R13) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R70-R83) [[3]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R100-R108) [[4]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L131-R135) [[5]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L147-R149)
* [`src/Docker/Command/BaseCommand.php`](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R219): Added `BindAddressAlreadyUseException` to the list of exceptions thrown by the `execute` method.
* [`src/Docker/Command/RunCommand.php`](diffhunk://#diff-004f9b58cf5a76a41c0b5bc78283c320751aab57b7bd953392e7b0adcbe5363aR5-R7): Added new exception classes `BindAddressAlreadyUseException`, `NoSuchContainerException`, and `NoSuchObjectException` to the `run` method. [[1]](diffhunk://#diff-004f9b58cf5a76a41c0b5bc78283c320751aab57b7bd953392e7b0adcbe5363aR5-R7) [[2]](diffhunk://#diff-004f9b58cf5a76a41c0b5bc78283c320751aab57b7bd953392e7b0adcbe5363aR45-R48)

### Documentation updates:

* [`src/Containers/GenericContainer/NetworkModeSetting.php`](diffhunk://#diff-a65b8a09317cdcca8660fd98bc9aedf1bd83ed6cadde92e7d76b2537ded2a4d4R7-R26): Added detailed documentation for the `NetworkModeSetting` trait, explaining the supported formats.

### Test case updates:

* `tests/Unit/Containers/BindModeTest.php`, `tests/Unit/Containers/GenericContainer/LabelSettingTest.php`, `tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php`, `tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php`, `tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php`, `tests/Unit/Containers/GenericContainer/WorkdirSettingTest.php`, `tests/Unit/Containers/GenericContainerInstanceTest.php`: Removed `@noinspection PhpUnhandledExceptionInspection` annotations from various test methods to clean up the test code. [[1]](diffhunk://#diff-64f97ffba42e56cc720d315d413a04ee1ed53db6eb23684618536efcef831e08R3-R4) [[2]](diffhunk://#diff-64f97ffba42e56cc720d315d413a04ee1ed53db6eb23684618536efcef831e08L41-L49) [[3]](diffhunk://#diff-64f97ffba42e56cc720d315d413a04ee1ed53db6eb23684618536efcef831e08L60) [[4]](diffhunk://#diff-7d00d6530ad878388bf7ec66484b2c260951a5adc842063e70bb5886d3dc1e60L14-R14) [[5]](diffhunk://#diff-7d00d6530ad878388bf7ec66484b2c260951a5adc842063e70bb5886d3dc1e60L36) [[6]](diffhunk://#diff-7d00d6530ad878388bf7ec66484b2c260951a5adc842063e70bb5886d3dc1e60L49) [[7]](diffhunk://#diff-36977976ec3f7a5fe86736e2b5b206938c576f5bd2e6b0363687f63bccd8545bL32) [[8]](diffhunk://#diff-4597ca68365d6df00d6a6e0e4e49c8ee9ad50d1540edad807ec3a254c76aadd5L33) [[9]](diffhunk://#diff-30b47d8fd6b5e5814efef8d2a47cda2c8057206f9cffe06f7b74ec55fdcd8bd8L18-R18) [[10]](diffhunk://#diff-30b47d8fd6b5e5814efef8d2a47cda2c8057206f9cffe06f7b74ec55fdcd8bd8R46) [[11]](diffhunk://#diff-502046c9d5725808f30ac95c91e81d43e2f8cb98ea182569ca56288aa0ce56caL37) [[12]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R3-R4) [[13]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L92) [[14]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L106)
* [`tests/Unit/Containers/GenericContainer/GeneralSettingTest.php`](diffhunk://#diff-2825007639ab57bf2a2712e0a3a161c3afee563d2a4f53839f54b513c303b9a3R1-R52): Added new test cases to verify the `GeneralSetting` trait functionality.