### PR TITLE
Add dynamic Docker host resolution and enhance test coverage

### DIFF
--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -9,8 +9,8 @@ use Testcontainers\Docker\Exception\DockerException;
 use Testcontainers\Docker\Exception\NoSuchContainerException;
 use Testcontainers\Docker\Exception\NoSuchObjectException;
 use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
-
 use Testcontainers\Environments;
+
 use function Testcontainers\kebab;
 
 /**

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -10,6 +10,7 @@ use Testcontainers\Docker\Exception\NoSuchContainerException;
 use Testcontainers\Docker\Exception\NoSuchObjectException;
 use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
 
+use Testcontainers\Environments;
 use function Testcontainers\kebab;
 
 /**
@@ -223,8 +224,8 @@ trait BaseCommand
             return $host;
         }
         // Check if the host is set in the DOCKER_HOST environment variable
-        $host = getenv('DOCKER_HOST');
-        if (is_string($host)) {
+        $host = Environments::DOCKER_HOST();
+        if ($host) {
             return $host;
         }
 

--- a/src/Docker/Command/BaseCommand.php
+++ b/src/Docker/Command/BaseCommand.php
@@ -204,6 +204,34 @@ trait BaseCommand
     }
 
     /**
+     * Get the Docker host.
+     *
+     * @return string
+     */
+    public function getHost()
+    {
+        // Check if the host is set in the global options
+        $host = isset($this->options['host']) ? $this->options['host'] : null;
+        if (is_array($host)) {
+            return $host[0];
+        } elseif (is_string($host)) {
+            return $host;
+        }
+        // Check if the host is set in the environment variables
+        $host = isset($this->env['DOCKER_HOST']) ? $this->env['DOCKER_HOST'] : null;
+        if (is_string($host)) {
+            return $host;
+        }
+        // Check if the host is set in the DOCKER_HOST environment variable
+        $host = getenv('DOCKER_HOST');
+        if (is_string($host)) {
+            return $host;
+        }
+
+        return 'unix:///var/run/docker.sock';
+    }
+
+    /**
      * Execute a Docker command.
      *
      * @param string $command The command to execute.

--- a/src/Environments.php
+++ b/src/Environments.php
@@ -5,6 +5,7 @@ namespace Testcontainers;
 /**
  * Environments is a class that provides the ability to get environment variables.
  *
+ * @method static string|null DOCKER_HOST() The hostname of the docker instance
  * @method static string|null TESTCONTAINERS_HOST_OVERRIDE() Override the hostname retrieved from the container instance with the specified host regardless of the docker's host
  */
 class Environments

--- a/src/Environments.php
+++ b/src/Environments.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Testcontainers;
+
+/**
+ * Environments is a class that provides the ability to get environment variables.
+ *
+ * @method static string|null TESTCONTAINERS_HOST_OVERRIDE() Override the hostname retrieved from the container instance with the specified host regardless of the docker's host
+ */
+class Environments
+{
+    private function __construct()
+    {
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        $value = getenv($name);
+        if (is_string($value)) {
+            return $value;
+        } else {
+            return null;
+        }
+    }
+}

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -8,7 +8,10 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\ImagePullPolicy;
+use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\Types\ContainerId;
+use Testcontainers\Testcontainers;
+use Tests\Images\DinD;
 
 class GenericContainerInstanceTest extends TestCase
 {
@@ -52,6 +55,19 @@ class GenericContainerInstanceTest extends TestCase
         ]);
 
         $this->assertSame('localhost', $instance->getHost());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetHostFromOverride()
+    {
+        putenv('TESTCONTAINERS_HOST_OVERRIDE=override.local');
+        $instance = new GenericContainerInstance([
+            'containerId' => new ContainerId('8188d93d8a27'),
+        ]);
+
+        $this->assertSame('override.local', $instance->getHost());
     }
 
     public function testGetMappedPort()

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -8,10 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\GenericContainerInstance;
 use Testcontainers\Containers\ImagePullPolicy;
-use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\Types\ContainerId;
-use Testcontainers\Testcontainers;
-use Tests\Images\DinD;
 
 class GenericContainerInstanceTest extends TestCase
 {
@@ -57,17 +54,18 @@ class GenericContainerInstanceTest extends TestCase
         $this->assertSame('localhost', $instance->getHost());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetHostFromOverride()
     {
-        putenv('TESTCONTAINERS_HOST_OVERRIDE=override.local');
-        $instance = new GenericContainerInstance([
-            'containerId' => new ContainerId('8188d93d8a27'),
-        ]);
+        try {
+            putenv('TESTCONTAINERS_HOST_OVERRIDE=override.local');
+            $instance = new GenericContainerInstance([
+                'containerId' => new ContainerId('8188d93d8a27'),
+            ]);
 
-        $this->assertSame('override.local', $instance->getHost());
+            $this->assertSame('override.local', $instance->getHost());
+        } finally {
+            putenv('TESTCONTAINERS_HOST_OVERRIDE');
+        }
     }
 
     public function testGetMappedPort()

--- a/tests/Unit/Docker/Command/BaseCommandTest.php
+++ b/tests/Unit/Docker/Command/BaseCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Docker\Command;
+
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Docker\DockerClient;
+
+class BaseCommandTest extends TestCase
+{
+    public function testGetHostFromDefault()
+    {
+        $client = new DockerClient();
+
+        $this->assertSame('unix:///var/run/docker.sock', $client->getHost());
+    }
+
+    public function testGetHostFromOptions()
+    {
+        $client = (new DockerClient())
+            ->withGlobalOptions([
+                'host' => 'tcp://127.0.0.1:2375',
+            ]);
+
+        $this->assertSame('tcp://127.0.0.1:2375', $client->getHost());
+    }
+
+    public function testGetHostFromEnv()
+    {
+        $client = (new DockerClient())
+            ->withEnv([
+                'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
+            ]);
+
+        $this->assertSame('tcp://127.0.0.1:2375', $client->getHost());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetHostFromGlobalEnv()
+    {
+        putenv('DOCKER_HOST=tcp://127.0.0.1:2375');
+        $client = new DockerClient();
+
+        $this->assertSame('tcp://127.0.0.1:2375', $client->getHost());
+    }
+}

--- a/tests/Unit/Docker/Command/BaseCommandTest.php
+++ b/tests/Unit/Docker/Command/BaseCommandTest.php
@@ -9,9 +9,16 @@ class BaseCommandTest extends TestCase
 {
     public function testGetHostFromDefault()
     {
-        $client = new DockerClient();
+        $backup = getenv('DOCKER_HOST');
 
-        $this->assertSame('unix:///var/run/docker.sock', $client->getHost());
+        try {
+            putenv('DOCKER_HOST');
+            $client = new DockerClient();
+
+            $this->assertSame('unix:///var/run/docker.sock', $client->getHost());
+        } finally {
+            putenv('DOCKER_HOST=' . $backup);
+        }
     }
 
     public function testGetHostFromOptions()
@@ -34,14 +41,17 @@ class BaseCommandTest extends TestCase
         $this->assertSame('tcp://127.0.0.1:2375', $client->getHost());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetHostFromGlobalEnv()
     {
-        putenv('DOCKER_HOST=tcp://127.0.0.1:2375');
-        $client = new DockerClient();
+        $backup = getenv('DOCKER_HOST');
 
-        $this->assertSame('tcp://127.0.0.1:2375', $client->getHost());
+        try {
+            putenv('DOCKER_HOST=tcp://127.0.0.1:2375');
+            $client = new DockerClient();
+
+            $this->assertSame('tcp://127.0.0.1:2375', $client->getHost());
+        } finally {
+            putenv('DOCKER_HOST=' . $backup);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to support dynamic Docker host resolution and enhance the test coverage for the `GenericContainerInstance` and `BaseCommand` classes. The most important changes include the addition of the `Environments` class, modifications to the `getHost` method in `GenericContainerInstance` and `BaseCommand`, and new test cases to verify the host resolution logic.

### Enhancements to Docker host resolution:

* [`src/Containers/GenericContainer/GenericContainerInstance.php`](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL128-R148): Modified the `getHost` method to support hostname resolution from environment variables and Docker client configuration.
* [`src/Docker/Command/BaseCommand.php`](diffhunk://#diff-b97459407809a73f92e9f0697e3f975d801475f5f97533b53c3da9b94a614b66R207-R234): Added a `getHost` method to resolve the Docker host from global options, environment variables, or default to the Unix socket.
* [`src/Environments.php`](diffhunk://#diff-342136a0fb25f38fa92983d22b626d77b52c3a82b51f618e2637ea4f0bf27a41R1-R26): Introduced the `Environments` class to provide a centralized way to access environment variables for Docker host configuration.

### Improved test coverage:

* [`tests/Unit/Containers/GenericContainerInstanceTest.php`](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497R60-R72): Added a test case to verify the `getHost` method with `TESTCONTAINERS_HOST_OVERRIDE` environment variable.
* [`tests/Unit/Docker/Command/BaseCommandTest.php`](diffhunk://#diff-3cfd94698724e9c8a172d30c6a131bb5f029fc2530fb9ab2b2082e9d1cf41975R1-R47): Added multiple test cases to verify the `getHost` method in different scenarios, including default value, global options, and environment variables.