### PR TITLE
Add SSH Port Forwarding and Enhance CI Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2.1
+
+jobs:
+  docker_executor:
+    docker:
+      - image: cimg/php:8.3
+    steps:
+      - run: env
+      - checkout
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v1-dependencies-docker-{{ checksum "composer.json" }}
+            - v1-dependencies-docker-
+      - run: composer install -n --prefer-dist
+      - save_cache:
+          key: v1-dependencies-docker-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - run: composer e2e
+  machine_executor:
+    machine: true
+    steps:
+      - run: env
+      - run:
+          name: Update packages and install PHP dependencies
+          command: |
+            sudo apt-get install ca-certificates apt-transport-https software-properties-common
+            sudo add-apt-repository -y ppa:ondrej/php
+            sudo apt-get update
+            sudo apt-get install -y php8.3 php8.3-dom php8.3-mbstring php8.3-xml php8.3-xmlwriter php8.3-pdo php8.3-mysql
+      - run:
+          name: Install Composer
+          command: |
+            curl -sS https://getcomposer.org/installer | php
+            sudo mv composer.phar /usr/local/bin/composer
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-machine-{{ checksum "composer.json" }}
+            - v1-dependencies-machine-
+      - run: composer install -n --prefer-dist --ignore-platform-reqs
+      - save_cache:
+          key: v1-dependencies-machine-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - run: composer e2e
+
+workflows:
+  e2e:
+    jobs:
+      - docker_executor
+      - machine_executor

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "lint": [
             "@lint:php-cs-fixer"
         ],
-        "test": "phpunit tests"
+        "test": "phpunit --testsuite unit",
+        "e2e": "phpunit --testsuite e2e"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,8 +11,11 @@
          backupStaticProperties="false">
 
   <testsuites>
-    <testsuite name="Project Test Suite">
-      <directory>tests</directory>
+    <testsuite name="unit">
+      <directory>tests/Unit</directory>
+    </testsuite>
+    <testsuite name="e2e">
+      <directory>tests/E2E</directory>
     </testsuite>
   </testsuites>
 

--- a/src/Containers/GenericContainer/SSHPortForwardSetting.php
+++ b/src/Containers/GenericContainer/SSHPortForwardSetting.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Testcontainers\Containers\GenericContainer;
+
+use Testcontainers\Environments;
+
+/**
+ * SSHPortForwardSetting is a trait that provides the ability to set up SSH port forwarding to the remote host that starts the container.
+ *
+ * Two formats are supported:
+ * 1. static variable `$SSH_PORT_FORWARD`:
+ *
+ * <code>
+ *     class YourContainer extends GenericContainer
+ *     {
+ *         protected static $EXPOSED_PORTS = [80];
+ *
+ *         protected static $SSH_PORT_FORWARD = 'user@host:port';
+ *     }
+ * </code>
+ *
+ * 2. method `withSSHPortForward`:
+ *
+ * <code>
+ *     $container = (new YourContainer('image'))
+ *        ->withExposedPort(80)
+ *        ->withSSHPortForward('host', 22, 'user');
+ * </code>
+ */
+trait SSHPortForwardSetting
+{
+    /**
+     * Define the default SSH port forwarding to be used for the container.
+     * @var string|bool|null
+     */
+    protected static $SSH_PORT_FORWARD;
+
+    /**
+     * @var array{
+     *     sshUser?: string|null,
+     *     sshHost: string,
+     *     sshPort?: int|null,
+     * }|bool|null
+     */
+    private $sshPortForward;
+
+    /**
+     * Set up SSH port forwarding to the remote host that starts the container.
+     *
+     * @param string $sshHost The SSH host to forward to.
+     * @param int|null $sshPort The SSH port to forward to.
+     * @param string|null $sshUser The SSH user to use for the connection.
+     * @return $this
+     */
+    public function withSSHPortForward($sshHost, $sshPort = null, $sshUser = null)
+    {
+        $this->sshPortForward = [
+            'sshUser' => $sshUser,
+            'sshHost' => $sshHost,
+            'sshPort' => $sshPort,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the SSH port forwarding to be used for the container.
+     *
+     * @return array{
+     *     sshUser?: string|null,
+     *     sshHost?: string|null,
+     *     sshPort?: int|null,
+     * }|null
+     */
+    protected function sshPortForward()
+    {
+        if (self::$SSH_PORT_FORWARD !== null) {
+            if (is_bool(self::$SSH_PORT_FORWARD)) {
+                return self::$SSH_PORT_FORWARD ? [
+                    'sshUser' => null,
+                    'sshHost' => null,
+                    'sshPort' => null,
+                ] : null;
+            } else {
+                return $this->parseSSHString(self::$SSH_PORT_FORWARD);
+            }
+        }
+        if ($this->sshPortForward !== null) {
+            if (is_bool($this->sshPortForward)) {
+                return $this->sshPortForward ? [
+                    'sshUser' => null,
+                    'sshHost' => null,
+                    'sshPort' => null,
+                ] : null;
+            } else {
+                return $this->sshPortForward;
+            }
+        }
+        $env = Environments::TESTCONTAINERS_SSH_FEEDFORWARDING();
+        if ($env !== null) {
+            return $this->parseSSHString($env);
+        }
+        return null;
+    }
+
+    /**
+     * Parse an SSH string into its components.
+     * The string should be in the format `[user@]host[:port]`.
+     *
+     * @return array{
+     *     sshUser?: string|null,
+     *     sshHost?: string|null,
+     *     sshPort?: int|null,
+     * }|null
+     */
+    private function parseSSHString($s)
+    {
+        $parts = explode('@', $s, 2);
+        if (count($parts) === 2) {
+            $sshUser = $parts[0];
+            $parts = explode(':', $parts[1], 2);
+            if (count($parts) === 2) {
+                $sshHost = $parts[0];
+                $sshPort = (int) $parts[1];
+            } else {
+                $sshHost = $parts[0];
+                $sshPort = null;
+            }
+        } else {
+            $sshUser = null;
+            $parts = explode(':', $s, 2);
+            if (count($parts) === 2) {
+                $sshHost = $parts[0];
+                $sshPort = (int)$parts[1];
+            } else {
+                $sshHost = $s;
+                $sshPort = null;
+            }
+        }
+        return [
+            'sshUser' => $sshUser,
+            'sshHost' => $sshHost,
+            'sshPort' => $sshPort,
+        ];
+    }
+}

--- a/src/Environments.php
+++ b/src/Environments.php
@@ -7,13 +7,11 @@ namespace Testcontainers;
  *
  * @method static string|null DOCKER_HOST() The hostname of the docker instance
  * @method static string|null TESTCONTAINERS_HOST_OVERRIDE() Override the hostname retrieved from the container instance with the specified host regardless of the docker's host
+ * @method static string|null TESTCONTAINERS_SSH_FEEDFORWARDING() Enable SSH port forwarding to the remote host that starts the container. The value should be a string in the format `[sshUser@]sshHost[:sshPort]`
+ * @method static string|null TESTCONTAINERS_SSH_FEEDFORWARDING_REMOTE_HOST_OVERRIDE() The remote host to which the SSH port forwarding should be enabled
  */
 class Environments
 {
-    private function __construct()
-    {
-    }
-
     public static function __callStatic($name, $arguments)
     {
         $value = getenv($name);

--- a/src/SSH/Exceptions/TunnelException.php
+++ b/src/SSH/Exceptions/TunnelException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Testcontainers\SSH\Exceptions;
+
+use RuntimeException;
+
+class TunnelException extends RuntimeException
+{
+}

--- a/src/SSH/Session.php
+++ b/src/SSH/Session.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Testcontainers\SSH;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * This class represents an SSH session managed by a Symfony Process.
+ * It provides methods to check if the session is running and to stop the session.
+ */
+class Session
+{
+    /**
+     * The process to use for the SSH session.
+     *
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @param Process $process The process to use for the SSH session.
+     */
+    public function __construct($process)
+    {
+        $this->process = $process;
+    }
+
+    public function __destruct()
+    {
+        $this->stop();
+    }
+
+    /**
+     * Check if the SSH session is currently running.
+     *
+     * @return bool
+     */
+    public function isRunning()
+    {
+        return $this->process->isRunning();
+    }
+
+    /**
+     * Stops the SSH session.
+     *
+     * @return void
+     */
+    public function stop()
+    {
+        $this->process->stop();
+    }
+}

--- a/src/SSH/Tunnel.php
+++ b/src/SSH/Tunnel.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Testcontainers\SSH;
+
+use InvalidArgumentException;
+use Symfony\Component\Process\Process;
+use Testcontainers\SSH\Exceptions\TunnelException;
+
+/**
+ * A tunnel for forwarding connections over SSH.
+ */
+class Tunnel
+{
+    /**
+     * The local port to bind to.
+     * @var int
+     */
+    protected $localPort;
+
+    /**
+     * The remote host to connect to.
+     * @var string
+     */
+    protected $remoteHost;
+
+    /**
+     * The remote port to connect to.
+     * @var int
+     */
+    protected $remotePort;
+
+    /**
+     * The SSH host to connect to.
+     * @var string
+     */
+    protected $sshHost;
+
+    /**
+     * The user to connect as.
+     * @var string|null
+     */
+    protected $user = null;
+
+    /**
+     * The SSH port to connect to.
+     * @var int|null
+     */
+    protected $sshPort = null;
+
+    /**
+     * The local bind address.
+     * @var string|null
+     */
+    protected $localBindAddress = null;
+
+    /**
+     * The identity file to use.
+     * @var string|null
+     */
+    protected $identityFile = null;
+
+    /**
+     * The SSH options to use.
+     * @var array
+     */
+    protected $sshOptions = [];
+
+    /**
+     * @param int $localPort The local port to bind to.
+     * @param string $remoteHost The remote host to connect to.
+     * @param int $remotePort The remote port to connect to.
+     * @param string $sshHost The SSH host to connect to.
+     */
+    public function __construct(
+        $localPort,
+        $remoteHost,
+        $remotePort,
+        $sshHost
+    ) {
+        $this->localPort  = $localPort;
+        $this->remoteHost = $remoteHost;
+        $this->remotePort = $remotePort;
+        $this->sshHost    = $sshHost;
+    }
+
+    /**
+     * Set the user to connect as.
+     *
+     * @param string $user The user to connect as.
+     * @return self
+     */
+    public function withUser($user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Set the SSH port to connect to.
+     *
+     * @param int $sshPort The SSH port to connect to.
+     * @return self
+     */
+    public function withSshPort($sshPort)
+    {
+        $this->sshPort = $sshPort;
+
+        return $this;
+    }
+
+    /**
+     * Set the local bind address.
+     *
+     * @param string $localBindAddress The local bind address.
+     * @return self
+     */
+    public function withLocalBindAddress($localBindAddress)
+    {
+        $this->localBindAddress = $localBindAddress;
+        return $this;
+    }
+
+    /**
+     * Set the identity file to use.
+     *
+     * @param string $identityFile The identity file to use.
+     * @return self
+     */
+    public function withIdentityFile($identityFile)
+    {
+        $this->identityFile = $identityFile;
+
+        return $this;
+    }
+
+    /**
+     * Set the SSH options to use.
+     *
+     * @param array $sshOptions The SSH options to use.
+     * @return self
+     */
+    public function withSshOptions($sshOptions)
+    {
+        $this->sshOptions = $sshOptions;
+
+        return $this;
+    }
+
+    /**
+     * Add an SSH option to use.
+     *
+     * @param string $option The SSH option to use.
+     * @param string $value The value of the SSH option.
+     * @return self
+     */
+    public function withSshOption($option, $value)
+    {
+        $this->sshOptions[$option] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Open the tunnel.
+     *
+     * @return Session
+     */
+    public function open()
+    {
+        $commandParts = [
+            'ssh',
+            '-v',
+            '-o',
+            'ExitOnForwardFailure=yes',
+            '-N',
+            '-L',
+        ];
+        if ($this->localBindAddress) {
+            $commandParts[] = $this->localBindAddress . ':' . $this->localPort . ':' . $this->remoteHost . ':' . $this->remotePort;
+        } else {
+            $commandParts[] = $this->localPort . ':' . $this->remoteHost . ':' . $this->remotePort;
+        }
+        if ($this->user) {
+            $commandParts[] = $this->user . '@' . $this->sshHost;
+        } else {
+            $commandParts[] = $this->sshHost;
+        }
+        if ($this->sshPort) {
+            $commandParts[] = '-p';
+            $commandParts[] = $this->sshPort;
+        }
+        if ($this->identityFile) {
+            $commandParts[] = '-i';
+            $commandParts[] = $this->identityFile;
+        }
+        foreach ($this->sshOptions as $option => $value) {
+            $commandParts[] = '-o';
+            $commandParts[] = $option . '=' . $value;
+        }
+        $process = new Process($commandParts);
+        $process->start();
+
+        $time = time();
+        while (true) {
+            if (time() - $time > 10) {
+                $process->stop();
+                throw new TunnelException('Failed to start SSH tunnel: ' . implode(' ', $commandParts) . ': Timed out');
+            }
+            if (!$process->isRunning()) {
+                $err = trim($process->getErrorOutput());
+                $lastLine = substr($err, strrpos($err, "\n") + 1);
+                throw new TunnelException('Failed to start SSH tunnel: ' . implode(' ', $commandParts) . ': ' . $lastLine);
+            }
+            if (strpos($process->getErrorOutput(), 'Connection established.') !== false) {
+                break;
+            }
+            usleep(100);
+        }
+
+        return new Session($process);
+    }
+}

--- a/tests/E2E/CircleCI/DockerExecutorTest.php
+++ b/tests/E2E/CircleCI/DockerExecutorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\E2E\CircleCI;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\WaitStrategy\PDO\MySQLDSN;
+use Testcontainers\Containers\WaitStrategy\PDO\PDOConnectWaitStrategy;
+use Testcontainers\Testcontainers;
+
+class DockerExecutorTest extends TestCase
+{
+    public function test()
+    {
+        if (getenv('CIRCLECI') !== 'true' || getenv('DOCKER_HOST') === false) {
+            $this->markTestSkipped('This test is only for CircleCI (docker executor)');
+        }
+
+        $instance = Testcontainers::run(
+            (new GenericContainer('mysql:8'))
+            ->withExposedPort(3306)
+            ->withEnvs([
+                'MYSQL_ROOT_PASSWORD' => 'test',
+            ])
+            ->withWaitStrategy(
+                (new PDOConnectWaitStrategy())
+                    ->withDsn(new MySQLDSN())
+                    ->withUsername('root')
+                    ->withPassword('test')
+            )
+            ->withSSHPortForward('remote-docker')
+        );
+
+        $pdo = new PDO('mysql:host=127.0.0.1;port=' . $instance->getMappedPort(3306), 'root', 'test');
+        $result = $pdo->query('SELECT 1')->fetchColumn();
+
+        $this->assertSame(1, $result);
+    }
+}

--- a/tests/E2E/CircleCI/MachineExecutorTest.php
+++ b/tests/E2E/CircleCI/MachineExecutorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\E2E\CircleCI;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\WaitStrategy\PDO\MySQLDSN;
+use Testcontainers\Containers\WaitStrategy\PDO\PDOConnectWaitStrategy;
+use Testcontainers\Testcontainers;
+
+class MachineExecutorTest extends TestCase
+{
+    public function test()
+    {
+        if (getenv('CIRCLECI') !== 'true' || getenv('DOCKER_HOST') !== false) {
+            $this->markTestSkipped('This test is only for CircleCI (machine executor)');
+        }
+
+        $instance = Testcontainers::run(
+            (new GenericContainer('mysql:8'))
+                ->withExposedPort(3306)
+                ->withEnvs([
+                    'MYSQL_ROOT_PASSWORD' => 'test',
+                ])
+                ->withWaitStrategy(
+                    (new PDOConnectWaitStrategy())
+                        ->withDsn(new MySQLDSN())
+                        ->withUsername('root')
+                        ->withPassword('test')
+                )
+        );
+
+        $pdo = new PDO('mysql:host=127.0.0.1;port=' . $instance->getMappedPort(3306), 'root', 'test');
+        $result = $pdo->query('SELECT 1')->fetchColumn();
+
+        $this->assertSame(1, $result);
+    }
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the project, including updates to the CI configuration, enhancements to the `GenericContainer` class, and the addition of new tests. Here are the most important changes:

### CI Configuration Updates:
* Added a new CircleCI configuration file `.circleci/config.yml` to define jobs for `docker_executor` and `machine_executor`, including steps to install dependencies, run tests, and cache dependencies.

### Enhancements to `GenericContainer`:
* Introduced the `SSHPortForwardSetting` trait to the `GenericContainer` class, enabling SSH port forwarding for containers. This includes adding the trait to the class and updating the `start` method to handle SSH port forwarding. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R33) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R154-R176) [[3]](diffhunk://#diff-8166a5652d15855a31421524071069efc7054b500bd58f54576ecc32d00479a6R1-R146)
* Updated `Environments.php` to include methods for SSH port forwarding environment variables.

### New Classes for SSH Handling:
* Added `Tunnel` and `Session` classes to manage SSH tunnels and sessions, including methods to open and stop SSH sessions. [[1]](diffhunk://#diff-c155e6ee35a826001ded06944e7201e36c14354860de70a3b41bc3b4240be9f2R1-R223) [[2]](diffhunk://#diff-841ef2ba3732d0da75e4383a6fbf714ea092eebbcd3fe17083f3f6013ac8aa1fR1-R52)
* Added `TunnelException` class to handle exceptions related to SSH tunnels.

### Test Suite Enhancements:
* Modified `composer.json` to include new `e2e` test suite and updated `phpunit.xml.dist` to define separate `unit` and `e2e` test suites. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L47-R48) [[2]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L14-R18)
* Added new end-to-end tests for CircleCI `docker_executor` and `machine_executor` in `tests/E2E/CircleCI/DockerExecutorTest.php` and `tests/E2E/CircleCI/MachineExecutorTest.php`. [[1]](diffhunk://#diff-5db438f238b601554d37a4f46945e2120892acf5ea221d43644db771a13c4889R1-R40) [[2]](diffhunk://#diff-fb1b37251386d3665b30a191ef138e1ba66679ae97b2c61ccc3fff5f881596b9R1-R39)