### PR TITLE
Add getHost and getPort methods and improve DSN handling

### DIFF
--- a/src/Containers/WaitStrategy/PDO/DSN.php
+++ b/src/Containers/WaitStrategy/PDO/DSN.php
@@ -16,12 +16,26 @@ interface DSN
     public function withHost($host);
 
     /**
+     * Get the host for the DSN.
+     *
+     * @return string|null
+     */
+    public function getHost();
+
+    /**
      * Set the port for the DSN.
      *
      * @param int $port The port to set.
      * @return $this
      */
     public function withPort($port);
+
+    /**
+     * Get the port for the DSN.
+     *
+     * @return int|null
+     */
+    public function getPort();
 
     /**
      * Convert the DSN to a string representation.

--- a/src/Containers/WaitStrategy/PDO/MySQLDSN.php
+++ b/src/Containers/WaitStrategy/PDO/MySQLDSN.php
@@ -54,11 +54,27 @@ class MySQLDSN implements DSN
     /**
      * {@inheritdoc}
      */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function withPort($port)
     {
         $this->port = $port;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPort()
+    {
+        return $this->port;
     }
 
     /**

--- a/src/Containers/WaitStrategy/PDO/SQLiteDSN.php
+++ b/src/Containers/WaitStrategy/PDO/SQLiteDSN.php
@@ -15,9 +15,25 @@ class SQLiteDSN implements DSN
     /**
      * {@inheritdoc}
      */
+    public function getHost()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function withPort($port)
     {
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPort()
+    {
+        return null;
     }
 
     /**

--- a/src/Containers/WaitStrategy/WaitingTimeoutException.php
+++ b/src/Containers/WaitStrategy/WaitingTimeoutException.php
@@ -15,15 +15,17 @@ class WaitingTimeoutException extends RuntimeException
 {
     /**
      * @param int $timeout The timeout in seconds.
+     * @param string|null $message The exception message.
      * @param int $code The exception code.
      * @param Exception|null $previous The previous exception.
      */
-    public function __construct($timeout, $code = 0, $previous = null)
+    public function __construct($timeout, $message = null, $code = 0, $previous = null)
     {
         parent::__construct(
             sprintf(
-                "Waiting for container to be ready timed out after %d seconds.",
-                $timeout
+                "Waiting for container to be ready timed out after %d seconds: %s",
+                $timeout,
+                $message
             ),
             $code,
             $previous


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `WaitStrategy` component, particularly focusing on improving the handling of DSN (Data Source Name) configurations. The changes include adding getter methods for host and port in the DSN classes, refining the `waitUntilReady` method to handle null values more gracefully, and updating the `WaitingTimeoutException` to include more detailed error messages.

Enhancements to DSN classes:

* [`src/Containers/WaitStrategy/PDO/DSN.php`](diffhunk://#diff-468a93ca1de032e80fa23037d60c91fa19ac621b8d9209c6ad38dd39540548f8R18-R24): Added `getHost` and `getPort` methods to retrieve the host and port values. [[1]](diffhunk://#diff-468a93ca1de032e80fa23037d60c91fa19ac621b8d9209c6ad38dd39540548f8R18-R24) [[2]](diffhunk://#diff-468a93ca1de032e80fa23037d60c91fa19ac621b8d9209c6ad38dd39540548f8R33-R39)
* [`src/Containers/WaitStrategy/PDO/MySQLDSN.php`](diffhunk://#diff-1fb87033c4a28b264e72fb55370e0e690957e31610ae47db3d71c1e5f22a18ccR54-R61): Implemented the `getHost` and `getPort` methods to return the respective properties. [[1]](diffhunk://#diff-1fb87033c4a28b264e72fb55370e0e690957e31610ae47db3d71c1e5f22a18ccR54-R61) [[2]](diffhunk://#diff-1fb87033c4a28b264e72fb55370e0e690957e31610ae47db3d71c1e5f22a18ccR72-R79)
* [`src/Containers/WaitStrategy/PDO/SQLiteDSN.php`](diffhunk://#diff-d640f4a21acbb2744fcc11bb73347a02acec81f540234fe2d37302b6a8dcd58dR15-R22): Implemented the `getHost` and `getPort` methods to return null, as SQLite does not use these properties. [[1]](diffhunk://#diff-d640f4a21acbb2744fcc11bb73347a02acec81f540234fe2d37302b6a8dcd58dR15-R22) [[2]](diffhunk://#diff-d640f4a21acbb2744fcc11bb73347a02acec81f540234fe2d37302b6a8dcd58dR31-R38)

Improvements to `waitUntilReady` method:

* [`src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php`](diffhunk://#diff-420b2650993895bb388a5fce781151becb40eef80df780381fb292ee631a3c90L75-R94): Updated the `waitUntilReady` method to clone the DSN and set the host and port if they are null, and to handle exceptions more effectively by storing the last exception and including its message in the timeout exception. [[1]](diffhunk://#diff-420b2650993895bb388a5fce781151becb40eef80df780381fb292ee631a3c90L75-R94) [[2]](diffhunk://#diff-420b2650993895bb388a5fce781151becb40eef80df780381fb292ee631a3c90L102-R106)

Enhancement to exception handling:

* [`src/Containers/WaitStrategy/WaitingTimeoutException.php`](diffhunk://#diff-df8cbd6482a8912a777552271e3ae905c066e1a268bce605820ecfa728215c50R18-R28): Modified the constructor to accept an optional message parameter and include it in the exception message for more detailed error reporting.