### PR TITLE
Add Docker image build functionality with BuildCommand and DockerBuildOutput

### DIFF
--- a/src/Docker/Command/BuildCommand.php
+++ b/src/Docker/Command/BuildCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Testcontainers\Docker\Command;
+
+use Testcontainers\Docker\Exception\DockerException;
+use Testcontainers\Docker\Output\DockerBuildOutput;
+
+/**
+ * Build command for Docker command.
+ *
+ * This trait provides a method for building a Docker image using the `docker build` command.
+ */
+trait BuildCommand
+{
+    /**
+     * Build a Docker image from a Dockerfile.
+     *
+     * This method wraps the `docker build` command to build a Docker image from a specified Dockerfile.
+     *
+     * @param string $path The path to the directory containing the Dockerfile.
+     * @param array{
+     *     addHost?: string[],
+     *     allow?: string[],
+     *     annotation?: string[],
+     *     attest?: string[],
+     *     buildArg?: string[],
+     *     buildContext?: string,
+     *     builder?: string,
+     *     cacheFrom?: string[],
+     *     cacheTo?: string[],
+     *     call?: string,
+     *     cgroupParent?: string,
+     *     check?: boolean,
+     *     debug?: boolean,
+     *     file?: string,
+     *     iidfile?: string,
+     *     label?: string[],
+     *     load?: boolean,
+     *     metadataFile?: string,
+     *     network?: string,
+     *     noCache?: boolean,
+     *     noCacheFilter?: string,
+     *     output?: string,
+     *     platform?: string,
+     *     progress?: string,
+     *     provenance?: string,
+     *     pull?: boolean,
+     *     push?: boolean,
+     *     quiet?: boolean,
+     *     sbom?: string,
+     *     secret?: string[],
+     *     shmSize?: string,
+     *     ssh?: string,
+     *     tag?: string,
+     *     target?: string,
+     *     ulimit?: string,
+     * } $options Additional options for the Docker command.
+     * @return DockerBuildOutput The output of the Docker build command.
+     *
+     * @throws DockerException If the Docker command fails for any other reason.
+     */
+    public function build($path, $options = [])
+    {
+        $process = $this->execute('build', null, [$path], $options);
+        return new DockerBuildOutput($process);
+    }
+
+    abstract protected function execute($command, $subcommand = null, $args = [], $options = [], $wait = true);
+}

--- a/src/Docker/DockerClient.php
+++ b/src/Docker/DockerClient.php
@@ -3,6 +3,7 @@
 namespace Testcontainers\Docker;
 
 use Testcontainers\Docker\Command\BaseCommand;
+use Testcontainers\Docker\Command\BuildCommand;
 use Testcontainers\Docker\Command\InspectCommand;
 use Testcontainers\Docker\Command\LogsCommand;
 use Testcontainers\Docker\Command\NetworkCreateCommand;
@@ -18,6 +19,7 @@ use Testcontainers\Docker\Command\StopCommand;
 class DockerClient
 {
     use BaseCommand;
+    use BuildCommand;
     use InspectCommand;
     use LogsCommand;
     use NetworkCreateCommand;

--- a/src/Docker/Output/DockerBuildOutput.php
+++ b/src/Docker/Output/DockerBuildOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Testcontainers\Docker\Output;
+
+/**
+ * Represents the output of a Docker `build` command executed via Symfony Process.
+ *
+ * This class extends DockerOutput to provide methods for retrieving the standard output,
+ * error output, and exit code of the Docker `build` command.
+ */
+class DockerBuildOutput extends DockerOutput
+{
+}


### PR DESCRIPTION
This pull request introduces a new `BuildCommand` trait for Docker commands and integrates it into the `DockerClient` class. It also includes a new class to handle the output of Docker build commands.

Key changes include:

### New Build Command Implementation:
* [`src/Docker/Command/BuildCommand.php`](diffhunk://#diff-f1de2d69f431ee5b86ebde6c9aaaf07d934f1a1404ec664501d16c9a9a0a3c4cR1-R69): Added a new trait `BuildCommand` that provides a method for building a Docker image using the `docker build` command. This includes handling various options and returning the build output.

### Integration into Docker Client:
* [`src/Docker/DockerClient.php`](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R6): Integrated the new `BuildCommand` trait into the `DockerClient` class, allowing it to use the build functionality. [[1]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R6) [[2]](diffhunk://#diff-a2be6830e6002b92915bd140c0f1098e7e0898cc381f25561ffbc1a0dc14bac4R22)

### Docker Build Output Handling:
* [`src/Docker/Output/DockerBuildOutput.php`](diffhunk://#diff-eb765b0a1a486279114edb71caf1dd656797c62f4ab19d3e04360007a04b7c42R1-R13): Added a new class `DockerBuildOutput` that extends `DockerOutput` to handle the output of the Docker build command, including standard output, error output, and exit code.