### PR TITLE
Add StaticPortStrategy for fixed port mapping with conflict handling

### DIFF
--- a/src/Containers/GenericContainer/PortSetting.php
+++ b/src/Containers/GenericContainer/PortSetting.php
@@ -219,12 +219,12 @@ trait PortSetting
         if ($this->portStrategy) {
             return $this->portStrategy;
         }
-        
+
         $containerPorts = $this->exposedPorts();
         if (count($containerPorts) > 0) {
             return $this->portStrategyProvider->get('random');
         }
-        
+
         return null;
     }
 

--- a/src/Containers/GenericContainer/PortSetting.php
+++ b/src/Containers/GenericContainer/PortSetting.php
@@ -219,13 +219,17 @@ trait PortSetting
         if ($this->portStrategy) {
             return $this->portStrategy;
         }
+        
+        $containerPorts = $this->exposedPorts();
+        if (count($containerPorts) > 0) {
+            return $this->portStrategyProvider->get('random');
+        }
+        
         return null;
     }
 
     /**
      * Retrieve Map of ports to be exposed by the container.
-     *
-     * If an exposure port is set and the port strategy is empty, the random port strategy is used by default.
      *
      * @return array<int, int> Key-value pairs of container ports to host ports.
      */
@@ -233,9 +237,6 @@ trait PortSetting
     {
         $containerPorts = $this->exposedPorts();
         $strategy = $this->portStrategy();
-        if ($strategy === null && count($containerPorts) > 0) {
-            $strategy = $this->portStrategyProvider->get('random');
-        }
         if ($strategy) {
             $ports = [];
             foreach ($containerPorts as $containerPort) {

--- a/src/Containers/PortStrategy/StaticPortStrategy.php
+++ b/src/Containers/PortStrategy/StaticPortStrategy.php
@@ -13,7 +13,7 @@ class StaticPortStrategy implements PortStrategy
      * @var int
      */
     private $port;
-    
+
     /**
      * @param int $port The port to return.
      */
@@ -21,7 +21,7 @@ class StaticPortStrategy implements PortStrategy
     {
         $this->port = $port;
     }
-    
+
     /**
      * @inheritDoc
      */
@@ -29,7 +29,7 @@ class StaticPortStrategy implements PortStrategy
     {
         return $this->port;
     }
-    
+
     /**
      * @inheritDoc
      */

--- a/src/Containers/PortStrategy/StaticPortStrategy.php
+++ b/src/Containers/PortStrategy/StaticPortStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Testcontainers\Containers\PortStrategy;
+
+/**
+ * A port strategy that returns a fixed port.
+ * When a port conflict occurs, it fails (does not retry).
+ */
+class StaticPortStrategy implements PortStrategy
+{
+    /**
+     * The port to return.
+     * @var int
+     */
+    private $port;
+    
+    /**
+     * @param int $port The port to return.
+     */
+    public function __construct($port)
+    {
+        $this->port = $port;
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function conflictBehavior()
+    {
+        return ConflictBehavior::FAIL();
+    }
+}

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -7,6 +7,8 @@ namespace Tests\Unit\Containers;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\ContainerInstance;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
+use Testcontainers\Containers\PortStrategy\StaticPortStrategy;
+use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
 
 class GenericContainerTest extends TestCase
 {
@@ -17,5 +19,26 @@ class GenericContainerTest extends TestCase
 
         $this->assertInstanceOf(ContainerInstance::class, $instance);
         $this->assertNotEmpty($instance->getContainerId());
+    }
+
+    public function testContainerFailsOnPortConflictWithStaticPortStrategy()
+    {
+        $this->expectException(PortAlreadyAllocatedException::class);
+
+        $container1 = (new GenericContainer('alpine:latest'))
+            ->withExposedPort(80)
+            ->withPortStrategy(new StaticPortStrategy(50000))
+            ->withCommands(['tail', '-f', '/dev/null']);
+        
+        $instance1 = $container1->start();
+        
+        $this->assertInstanceOf(ContainerInstance::class, $instance1);
+        $this->assertEquals(50000, $instance1->getMappedPort(80));
+        
+        $container2 = (new GenericContainer('alpine:latest'))
+            ->withExposedPort(80)
+            ->withPortStrategy(new StaticPortStrategy(50000));
+        
+        $container2->start();
     }
 }

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -29,16 +29,16 @@ class GenericContainerTest extends TestCase
             ->withExposedPort(80)
             ->withPortStrategy(new StaticPortStrategy(50000))
             ->withCommands(['tail', '-f', '/dev/null']);
-        
+
         $instance1 = $container1->start();
-        
+
         $this->assertInstanceOf(ContainerInstance::class, $instance1);
         $this->assertEquals(50000, $instance1->getMappedPort(80));
-        
+
         $container2 = (new GenericContainer('alpine:latest'))
             ->withExposedPort(80)
             ->withPortStrategy(new StaticPortStrategy(50000));
-        
+
         $container2->start();
     }
 }

--- a/tests/Unit/Containers/PortStrategy/RandomPortStrategyTest.php
+++ b/tests/Unit/Containers/PortStrategy/RandomPortStrategyTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Containers\PortStrategy;
 
 use Testcontainers\Containers\PortStrategy\RandomPortStrategy;
 
-class LocalRandomPortStrategyTest extends PortStrategyTestCase
+class RandomPortStrategyTest extends PortStrategyTestCase
 {
     /**
      * @inheritDoc

--- a/tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php
+++ b/tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php
@@ -13,29 +13,29 @@ class StaticPortStrategyTest extends PortStrategyTestCase
     {
         return new StaticPortStrategy(50000);
     }
-    
+
     public function testInterfaceGetPort()
     {
         $strategy = $this->resolvePortStrategy();
         $port = $strategy->getPort();
-        
+
         $this->assertSame(50000, $port);
     }
-    
+
     public function testReturnsSpecifiedPort()
     {
         $strategy1 = new StaticPortStrategy(50001);
         $strategy2 = new StaticPortStrategy(50002);
-        
+
         $this->assertSame(50001, $strategy1->getPort());
         $this->assertSame(50002, $strategy2->getPort());
     }
-    
+
     public function testConflictBehaviorIsFail()
     {
         $strategy = $this->resolvePortStrategy();
         $behavior = $strategy->conflictBehavior();
-        
+
         $this->assertTrue($behavior->isFail());
         $this->assertFalse($behavior->isRetry());
     }

--- a/tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php
+++ b/tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\Containers\PortStrategy;
+
+use Testcontainers\Containers\PortStrategy\StaticPortStrategy;
+
+class StaticPortStrategyTest extends PortStrategyTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function resolvePortStrategy()
+    {
+        return new StaticPortStrategy(50000);
+    }
+    
+    public function testInterfaceGetPort()
+    {
+        $strategy = $this->resolvePortStrategy();
+        $port = $strategy->getPort();
+        
+        $this->assertSame(50000, $port);
+    }
+    
+    public function testReturnsSpecifiedPort()
+    {
+        $strategy1 = new StaticPortStrategy(50001);
+        $strategy2 = new StaticPortStrategy(50002);
+        
+        $this->assertSame(50001, $strategy1->getPort());
+        $this->assertSame(50002, $strategy2->getPort());
+    }
+    
+    public function testConflictBehaviorIsFail()
+    {
+        $strategy = $this->resolvePortStrategy();
+        $behavior = $strategy->conflictBehavior();
+        
+        $this->assertTrue($behavior->isFail());
+        $this->assertFalse($behavior->isRetry());
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the port strategy implementation and its associated tests. The most important changes include the addition of a new static port strategy, modifications to the existing port strategy logic, and updates to the unit tests to cover the new functionality.

### Port Strategy Updates:
* [`src/Containers/GenericContainer/PortSetting.php`](diffhunk://#diff-fb295030a82f001ba6bf462f13ec2789e3e6bf81b5eb0ba3b18abca106d834d3R222-L238): Modified the `portStrategy()` method to use the random port strategy if container ports are exposed and no strategy is set.

### New Static Port Strategy:
* [`src/Containers/PortStrategy/StaticPortStrategy.php`](diffhunk://#diff-2f148787ffa6ce84b5de08c8b7f159f78797f95ef7f0fab6975ce85281d26a3aR1-R40): Added a new `StaticPortStrategy` class that returns a fixed port and fails on port conflict.

### Unit Test Updates:
* [`tests/Unit/Containers/GenericContainerTest.php`](diffhunk://#diff-7e2bd3bc18d402812d92d1beb86c661b1680f0b1bc9171819de6c1deffe754e5R23-R43): Added a test to verify that a container fails on port conflict when using the static port strategy.
* [`tests/Unit/Containers/PortStrategy/RandomPortStrategyTest.php`](diffhunk://#diff-e286e2f9efc90e103c543405ec19b9867db121a532b515844291e0e0a66a98a5L7-R7): Renamed from `LocalRandomPortStrategyTest` to `RandomPortStrategyTest`.
* [`tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php`](diffhunk://#diff-68113930da34843b17ea70febc03501546d3165a5e1d683ac695fc165f7dc3b5R1-R42): Added a new test class to validate the behavior of the `StaticPortStrategy`.