### PR TITLE
Add container status methods and improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ composer.lock
 # Cline
 .clinerules
 .cline/
+
+# VSCode
+.vscode/

--- a/src/Containers/ContainerInstance.php
+++ b/src/Containers/ContainerInstance.php
@@ -106,4 +106,18 @@ interface ContainerInstance
      * @return null|T The data associated with the specified class.
      */
     public function tryGetData($class);
+
+    /**
+     * Checks if the container is currently running.
+     *
+     * @return bool True if the container is running, false otherwise.
+     */
+    public function isRunning();
+
+    /**
+     * Stops the container if it is running.
+     *
+     * @return void
+     */
+    public function stop();
 }

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -117,6 +117,9 @@ class GenericContainer implements Container
             } else {
                 $output = $client->run($image, $command, $args, $options);
             }
+            if (!($output instanceof DockerRunWithDetachOutput)) {
+                throw new LogicException('Expected DockerRunWithDetachOutput');
+            }
         } catch (PortAlreadyAllocatedException $e) {
             if ($portStrategy === null) {
                 throw $e;
@@ -143,10 +146,6 @@ class GenericContainer implements Container
             throw new LogicException('Unknown conflict behavior: `' . $behavior . '`', 0, $e);
         }
 
-        if (!($output instanceof DockerRunWithDetachOutput)) {
-            throw new LogicException('Expected DockerRunWithDetachOutput');
-        }
-        
         $containerDef = [
             'containerId' => $output->getContainerId(),
             'labels' => $this->labels(),

--- a/src/Containers/GenericContainer/GenericContainer.php
+++ b/src/Containers/GenericContainer/GenericContainer.php
@@ -117,9 +117,6 @@ class GenericContainer implements Container
             } else {
                 $output = $client->run($image, $command, $args, $options);
             }
-            if (!($output instanceof DockerRunWithDetachOutput)) {
-                throw new LogicException('Expected DockerRunWithDetachOutput');
-            }
         } catch (PortAlreadyAllocatedException $e) {
             if ($portStrategy === null) {
                 throw $e;
@@ -146,6 +143,10 @@ class GenericContainer implements Container
             throw new LogicException('Unknown conflict behavior: `' . $behavior . '`', 0, $e);
         }
 
+        if (!($output instanceof DockerRunWithDetachOutput)) {
+            throw new LogicException('Expected DockerRunWithDetachOutput');
+        }
+        
         $containerDef = [
             'containerId' => $output->getContainerId(),
             'labels' => $this->labels(),

--- a/src/Containers/GenericContainer/GenericContainerInstance.php
+++ b/src/Containers/GenericContainer/GenericContainerInstance.php
@@ -252,9 +252,7 @@ class GenericContainerInstance implements ContainerInstance
     }
 
     /**
-     * Checks if the container is currently running.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isRunning()
     {
@@ -278,11 +276,9 @@ class GenericContainerInstance implements ContainerInstance
             return false;
         }
     }
-
+    
     /**
-     * Stops the container if it is running.
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function stop()
     {

--- a/src/Containers/GenericContainer/GenericContainerInstance.php
+++ b/src/Containers/GenericContainer/GenericContainerInstance.php
@@ -276,7 +276,7 @@ class GenericContainerInstance implements ContainerInstance
             return false;
         }
     }
-    
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This pull request introduces several changes to the container management functionality, including new methods for checking and stopping container status, as well as adjustments to error handling in the container start process. The most important changes are listed below:

### New Methods for Container Status

* [`src/Containers/ContainerInstance.php`](diffhunk://#diff-9871ae1df65d02c2a8ec6ca1a21a3e0128f5324edd371a4f83a9759a8e72724fR109-R122): Added `isRunning` method to check if the container is running and `stop` method to stop the container if it is running.

### Error Handling Adjustments

* [`src/Containers/GenericContainer/GenericContainer.php`](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L120-L122): Moved the check for `DockerRunWithDetachOutput` to a later point in the `start` method to ensure it is only checked after the potential port allocation exception is handled. [[1]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027L120-L122) [[2]](diffhunk://#diff-bb4328d6eb3b86a6da3978c1b560d7bb17b9aa1789a42d8633eafaa7f78d8027R146-R149)

### Code Simplification

* [`src/Containers/GenericContainer/GenericContainerInstance.php`](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL255-R255): Replaced the detailed method documentation for `isRunning` and `stop` methods with `{@inheritdoc}` to inherit documentation from the parent class. [[1]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL255-R255) [[2]](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL283-R281)