### PR TITLE
Enhance CI configuration with opcache and xdebug adjustments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
+          ini-values: opcache.enable_cli=1
       - uses: ramsey/composer-install@v3
       - name: Run lint
         run: composer lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          coverage: none
       - uses: ramsey/composer-install@v3
       - name: Run lint
         run: composer lint


### PR DESCRIPTION
This pull request includes a small change to the `jobs:` section in the `.github/workflows/ci.yaml` file. The change adds configuration settings for PHP coverage and an ini value for enabling opcache in the CLI.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR17-R18): Added `coverage: none` and `ini-values: opcache.enable_cli=1` to the `setup-php` action configuration.