### PR TITLE
Refine host determination logic in GenericContainerInstance

### DIFF
--- a/src/Containers/GenericContainer/GenericContainerInstance.php
+++ b/src/Containers/GenericContainer/GenericContainerInstance.php
@@ -138,9 +138,6 @@ class GenericContainerInstance implements ContainerInstance
 
         $client = $this->client ?: DockerClientFactory::create();
         $host = $client->getHost();
-        if ($host !== null) {
-            return 'localhost';
-        }
         $url = parse_url($host);
         switch ($url['scheme']) {
             case 'http':


### PR DESCRIPTION
This pull request modifies the `getHost` method in the `GenericContainerInstance` class to refine the logic for determining the host value. The key change removes a conditional check that returned `'localhost'` when the `$host` value was not `null`.

Refinement to host determination logic:

* [`src/Containers/GenericContainer/GenericContainerInstance.php`](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eL141-L143): Removed the conditional block that returned `'localhost'` if `$host` was not `null`. This simplifies the method and ensures the host value is consistently parsed using `parse_url`.