### PR TITLE
Add timeout and retry interval configuration to IsRunningStartupCheckStrategy

### DIFF
--- a/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
@@ -22,6 +22,20 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
     private $client;
 
     /**
+     * The timeout duration in seconds.
+     *
+     * @var int the timeout duration in seconds
+     */
+    private $timeout = 30;
+
+    /**
+     * The interval in microseconds to wait before retrying the check.
+     *
+     * @var int the interval in seconds
+     */
+    private $retryInterval = 0;
+
+    /**
      * Sets the docker client.
      *
      * @param DockerClient $client the docker client
@@ -36,6 +50,34 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
     }
 
     /**
+     * Sets the timeout duration for waiting until the container instance is ready.
+     *
+     * @param int $seconds the number of seconds to wait before timing out
+     *
+     * @return $this the current instance for method chaining
+     */
+    public function withTimeoutSeconds($seconds)
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Sets the interval in microseconds to wait before retrying the check.
+     *
+     * @param int $interval the interval in microseconds
+     *
+     * @return $this the current instance for method chaining
+     */
+    public function withRetryInterval($interval)
+    {
+        $this->retryInterval = $interval;
+
+        return $this;
+    }
+
+    /**
      * Wait until the container startup is successful.
      *
      * @param ContainerInstance $instance the container instance to check
@@ -44,11 +86,17 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
      */
     public function waitUntilStartupSuccessful($instance)
     {
+        $now = time();
+
         $client = $this->client ?: DockerClientFactory::create();
 
         try {
             $this->logger()->debug('Waiting for container to be running...');
             while (true) {
+                if (time() - $now > $this->timeout) {
+                    throw new WaitingTimeoutException($this->timeout);
+                }
+
                 $output = $client->inspect($instance->getContainerId());
 
                 switch ($output->state->status) {
@@ -63,7 +111,7 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
                         $this->logger()->debug('Container is not running yet. Current status: ' . $output->state->status);
                         break;
                 }
-                usleep(0);
+                usleep($this->retryInterval);
             }
         } catch (\Exception $e) {
             $this->logger()->debug('Error while checking container status: ' . $e->getMessage());

--- a/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
+++ b/src/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategy.php
@@ -31,7 +31,7 @@ class IsRunningStartupCheckStrategy implements StartupCheckStrategy
     /**
      * The interval in microseconds to wait before retrying the check.
      *
-     * @var int the interval in seconds
+     * @var int the interval in microseconds
      */
     private $retryInterval = 0;
 

--- a/src/Containers/StartupCheckStrategy/WaitingTimeoutException.php
+++ b/src/Containers/StartupCheckStrategy/WaitingTimeoutException.php
@@ -1,12 +1,9 @@
 <?php
 
-namespace Testcontainers\Containers\WaitStrategy;
+namespace Testcontainers\Containers\StartupCheckStrategy;
 
 /**
- * Exception thrown when waiting for a container to be ready times out.
- *
- * This exception is used to indicate that the specified timeout duration
- * has been exceeded while waiting for the container to be ready.
+ * WaitingTimeoutException is thrown when a container fails to start within the specified timeout period.
  */
 class WaitingTimeoutException extends \RuntimeException
 {


### PR DESCRIPTION
This pull request enhances the `IsRunningStartupCheckStrategy` class by introducing configurable timeout and retry interval settings for container startup checks. It also adds a new exception class to handle timeout scenarios more explicitly.

### Enhancements to `IsRunningStartupCheckStrategy`:

* Added private properties `timeout` (default: 30 seconds) and `retryInterval` (default: 0 microseconds) to allow configuration of container startup checks.
* Introduced `withTimeoutSeconds()` and `withRetryInterval()` methods for setting timeout and retry interval values, enabling method chaining for better usability.
* Updated the `waitUntilStartupSuccessful()` method to enforce the timeout using the new `timeout` property and throw a `WaitingTimeoutException` if exceeded.
* Replaced the hardcoded `usleep(0)` with the configurable `retryInterval` property for flexible retry intervals.

### New Exception Class:

* Added `WaitingTimeoutException` in `src/Containers/StartupCheckStrategy/WaitingTimeoutException.php` to provide a clearer error message when a timeout occurs during container startup.