### PR TITLE
Set default socket timeout for PDO connection attempts and fix password typo in log message

### DIFF
--- a/src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php
+++ b/src/Containers/WaitStrategy/PDO/PDOConnectWaitStrategy.php
@@ -175,10 +175,14 @@ class PDOConnectWaitStrategy implements WaitStrategy
             $dsn = $dsn->withPort($port);
         }
 
+        $defaultSocketTimeout = ini_get('default_socket_timeout');
+        ini_set('default_socket_timeout', 1);
+
         $now = time();
         $ex = null;
         while (1) {
             if (time() - $now > $this->timeout) {
+                ini_set('default_socket_timeout', $defaultSocketTimeout);
                 if (null === $ex) {
                     $message = 'Timeout waiting for PDO connection';
                 } else {
@@ -189,7 +193,7 @@ class PDOConnectWaitStrategy implements WaitStrategy
 
             try {
                 $this->logger()->debug(sprintf(
-                    'Trying to connect to PDO: dsn=%s, username=%s, passowrd=%s',
+                    'Trying to connect to PDO: dsn=%s, username=%s, password=%s',
                     $dsn->toString(),
                     $this->username,
                     $this->password
@@ -211,5 +215,7 @@ class PDOConnectWaitStrategy implements WaitStrategy
             }
             usleep($this->retryInterval);
         }
+
+        ini_set('default_socket_timeout', $defaultSocketTimeout);
     }
 }


### PR DESCRIPTION
This pull request makes improvements to the `waitUntilReady` method in the `PDOConnectWaitStrategy` class, focusing on enhancing reliability and fixing a typo in logging.

### Improvements to reliability:
* Temporarily sets the `default_socket_timeout` to 1 second at the beginning of the connection attempt and restores it to its original value when the timeout is reached or the method completes. This ensures that socket timeouts during the connection attempt are handled more predictably. [[1]](diffhunk://#diff-420b2650993895bb388a5fce781151becb40eef80df780381fb292ee631a3c90R178-R185) [[2]](diffhunk://#diff-420b2650993895bb388a5fce781151becb40eef80df780381fb292ee631a3c90R218-R219)

### Logging improvement:
* Corrected a typo in the debug log message, changing "passowrd" to "password" for clarity and accuracy.