### PR TITLE
Prevent stopping a container that is not running

### DIFF
--- a/src/Containers/GenericContainer/GenericContainerInstance.php
+++ b/src/Containers/GenericContainer/GenericContainerInstance.php
@@ -242,6 +242,9 @@ class GenericContainerInstance implements ContainerInstance
 
     public function stop()
     {
+        if (!$this->isRunning()) {
+            return;
+        }
         try {
             $client = $this->client ?: DockerClientFactory::create();
             $client->stop($this->containerDef['containerId']);


### PR DESCRIPTION
This pull request introduces a safeguard to the `stop` method in the `GenericContainerInstance` class to prevent unnecessary operations when the container is not running.

Key change:

* [`src/Containers/GenericContainer/GenericContainerInstance.php`](diffhunk://#diff-a5750228b6b78763c30fedc064612dde9830540a61a350ebf33cb344a73e1f1eR245-R247): Added a check in the `stop` method to return early if the container is not running by using the `isRunning` method.