### PR TITLE
Handle deserialization failure by setting default container state to 'dead'

### DIFF
--- a/src/Containers/GenericContainer/GenericContainerInstance.php
+++ b/src/Containers/GenericContainer/GenericContainerInstance.php
@@ -67,7 +67,9 @@ class GenericContainerInstance implements ContainerInstance
 
     public function __destruct()
     {
-        $this->stop();
+        if ($this->running) {
+            $this->stop();
+        }
     }
 
     /**
@@ -242,9 +244,6 @@ class GenericContainerInstance implements ContainerInstance
 
     public function stop()
     {
-        if (!$this->isRunning()) {
-            return;
-        }
         try {
             $client = $this->client ?: DockerClientFactory::create();
             $client->stop($this->containerDef['containerId']);

--- a/src/Docker/Exception/PortAlreadyAllocatedException.php
+++ b/src/Docker/Exception/PortAlreadyAllocatedException.php
@@ -21,6 +21,6 @@ class PortAlreadyAllocatedException extends DockerException
     public static function match($output)
     {
         return false !== strpos($output, 'Error response from daemon:')
-            && false !== strpos($output, 'port is already allocated.');
+            && false !== strpos($output, 'port is already allocated');
     }
 }

--- a/src/Docker/Output/DockerInspectOutput.php
+++ b/src/Docker/Output/DockerInspectOutput.php
@@ -31,7 +31,12 @@ class DockerInspectOutput extends DockerOutput
         try {
             $this->object = $this->deserialize($process->getOutput());
         } catch (InvalidValueException $e) {
-            throw new \LogicException('Failed to deserialize Docker inspect output', 0, $e);
+            $this->object = ContainerObject::fromArray([
+                'State' => [
+                    'Status' => 'dead',
+                    'ExitCode' => 255,
+                ],
+            ]);
         }
     }
 


### PR DESCRIPTION
This pull request modifies the behavior of the `__construct` method in `DockerInspectOutput` to handle deserialization failures more gracefully by initializing a default `ContainerObject` instead of throwing an exception.

Error handling improvement:

* [`src/Docker/Output/DockerInspectOutput.php`](diffhunk://#diff-7d178cfe83617c317be702e05bd1d80b001eace5fb7c17d3935836c93f291a70L34-R39): Updated the `__construct` method to initialize a default `ContainerObject` with a "dead" state and an exit code of 255 when deserialization fails, replacing the previous logic that threw a `LogicException`.