### PR TITLE
Remove redundant test annotations and add PHPUnit coverage support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Update packages and install PHP dependencies
           command: |
-            sudo apt-get install ca-certificates apt-transport-https software-properties-common
+            sudo apt-get install ca-certificates software-properties-common
             sudo add-apt-repository -y ppa:ondrej/php
             sudo apt-get update
             sudo apt-get install -y php8.3 php8.3-dom php8.3-mbstring php8.3-xml php8.3-xmlwriter php8.3-pdo php8.3-mysql

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
             "@lint:php-cs-fixer"
         ],
         "test": "phpunit --testsuite unit",
+        "coverage": "phpunit --coverage-text --testsuite unit",
         "e2e": "phpunit --testsuite e2e"
     }
 }

--- a/phpunit.5.6.xml.dist
+++ b/phpunit.5.6.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          colors="true"
@@ -19,11 +19,11 @@
     </testsuite>
   </testsuites>
 
-  <source>
-    <include>
+  <filter>
+    <whitelist>
       <directory suffix=".php">src/</directory>
-    </include>
-  </source>
+    </whitelist>
+  </filter>
 
   <php>
     <ini name="error_reporting" value="-1"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          colors="true"
@@ -24,6 +24,12 @@
       <directory suffix=".php">src/</directory>
     </include>
   </source>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src/</directory>
+    </whitelist>
+  </filter>
 
   <php>
     <ini name="error_reporting" value="-1"/>

--- a/tests/E2E/CircleCI/DockerExecutorTest.php
+++ b/tests/E2E/CircleCI/DockerExecutorTest.php
@@ -11,11 +11,6 @@ use Testcontainers\Containers\WaitStrategy\PDO\MySQLDSN;
 use Testcontainers\Containers\WaitStrategy\PDO\PDOConnectWaitStrategy;
 use Testcontainers\Testcontainers;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class DockerExecutorTest extends TestCase
 {
     public function test()

--- a/tests/E2E/CircleCI/MachineExecutorTest.php
+++ b/tests/E2E/CircleCI/MachineExecutorTest.php
@@ -11,11 +11,6 @@ use Testcontainers\Containers\WaitStrategy\PDO\MySQLDSN;
 use Testcontainers\Containers\WaitStrategy\PDO\PDOConnectWaitStrategy;
 use Testcontainers\Testcontainers;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class MachineExecutorTest extends TestCase
 {
     public function test()

--- a/tests/Unit/Containers/BindModeTest.php
+++ b/tests/Unit/Containers/BindModeTest.php
@@ -8,11 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\Types\BindMode;
 use Testcontainers\Exceptions\InvalidFormatException;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class BindModeTest extends TestCase
 {
     public function testBindModeReadOnly()

--- a/tests/Unit/Containers/GenericContainer/EnvSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/EnvSettingTest.php
@@ -8,11 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer\EnvSetting;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class EnvSettingTest extends TestCase
 {
     public function testHasEnvSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/GeneralSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/GeneralSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GeneralSetting;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class GeneralSettingTest extends TestCase
 {
     public function testHasGeneralSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/HostSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/HostSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\HostSetting;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class HostSettingTest extends TestCase
 {
     public function testHasHostSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/LabelSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/LabelSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\LabelSetting;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class LabelSettingTest extends TestCase
 {
     public function testHasLabelSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/MountSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/MountSettingTest.php
@@ -12,11 +12,6 @@ use Testcontainers\Containers\Types\Mount;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 use Testcontainers\Docker\DockerClientFactory;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class MountSettingTest extends TestCase
 {
     public function testHasMountSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/NetworkAliasSettingTest.php
@@ -12,11 +12,6 @@ use Testcontainers\Docker\DockerClientFactory;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class NetworkAliasSettingTest extends TestCase
 {
     public function testHasNetworkAliasSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/NetworkModeSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\NetworkModeSetting;
 use Testcontainers\Containers\Types\NetworkMode;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class NetworkModeSettingTest extends TestCase
 {
     public function testHasNetworkModeSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/PortSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PortSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\PortSetting;
 use Testcontainers\Containers\PortStrategy\RandomPortStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class PortSettingTest extends TestCase
 {
     public function testHasPortSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PrivilegeSettingTest.php
@@ -8,11 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\PrivilegeSetting;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class PrivilegeSettingTest extends TestCase
 {
     public function testHasPrivilegeSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/PullPolicySettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\PullPolicySetting;
 use Testcontainers\Containers\Types\ImagePullPolicy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class PullPolicySettingTest extends TestCase
 {
     public function testHasPullPolicySettingTrait()

--- a/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/StartupSettingTest.php
@@ -10,11 +10,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\StartupSetting;
 use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class StartupSettingTest extends TestCase
 {
     public function testHasStartupSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/VolumesFromSettingTest.php
@@ -13,11 +13,6 @@ use Testcontainers\Docker\DockerClientFactory;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class VolumesFromSettingTest extends TestCase
 {
     public function testHasVolumesFromSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/WaitSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/WaitSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\WaitSetting;
 use Testcontainers\Containers\WaitStrategy\HostPortWaitStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class WaitSettingTest extends TestCase
 {
     public function testHasWaitSettingTrait()

--- a/tests/Unit/Containers/GenericContainer/WorkdirSettingTest.php
+++ b/tests/Unit/Containers/GenericContainer/WorkdirSettingTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\GenericContainer\WorkdirSetting;
 use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class WorkdirSettingTest extends TestCase
 {
     public function testHasWorkdirSettingTrait()

--- a/tests/Unit/Containers/GenericContainerInstanceTest.php
+++ b/tests/Unit/Containers/GenericContainerInstanceTest.php
@@ -15,11 +15,6 @@ use Testcontainers\SSH\Session;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class GenericContainerInstanceTest extends TestCase
 {
     public function testGetContainerId()

--- a/tests/Unit/Containers/GenericContainerTest.php
+++ b/tests/Unit/Containers/GenericContainerTest.php
@@ -10,11 +10,6 @@ use Testcontainers\Containers\GenericContainer\GenericContainer;
 use Testcontainers\Containers\PortStrategy\StaticPortStrategy;
 use Testcontainers\Docker\Exception\PortAlreadyAllocatedException;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class GenericContainerTest extends TestCase
 {
     public function testStart()

--- a/tests/Unit/Containers/ImagePullPolicyTest.php
+++ b/tests/Unit/Containers/ImagePullPolicyTest.php
@@ -8,11 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\Types\ImagePullPolicy;
 use Testcontainers\Exceptions\InvalidFormatException;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class ImagePullPolicyTest extends TestCase
 {
     public function testImagePullPolicyAlways()

--- a/tests/Unit/Containers/PortStrategy/ConflictBehaviorTest.php
+++ b/tests/Unit/Containers/PortStrategy/ConflictBehaviorTest.php
@@ -8,11 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\PortStrategy\ConflictBehavior;
 use Testcontainers\Exceptions\InvalidFormatException;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class ConflictBehaviorTest extends TestCase
 {
     public function testConflictBehaviorRetry()

--- a/tests/Unit/Containers/PortStrategy/PortStrategyProviderTest.php
+++ b/tests/Unit/Containers/PortStrategy/PortStrategyProviderTest.php
@@ -10,11 +10,6 @@ use Testcontainers\Containers\PortStrategy\ConflictBehavior;
 use Testcontainers\Containers\PortStrategy\PortStrategy;
 use Testcontainers\Containers\PortStrategy\PortStrategyProvider;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class PortStrategyProviderTest extends TestCase
 {
     public function testRegister()

--- a/tests/Unit/Containers/PortStrategy/RandomPortStrategyTest.php
+++ b/tests/Unit/Containers/PortStrategy/RandomPortStrategyTest.php
@@ -4,11 +4,6 @@ namespace Tests\Unit\Containers\PortStrategy;
 
 use Testcontainers\Containers\PortStrategy\RandomPortStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class RandomPortStrategyTest extends PortStrategyTestCase
 {
     public function resolvePortStrategy()

--- a/tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php
+++ b/tests/Unit/Containers/PortStrategy/StaticPortStrategyTest.php
@@ -4,11 +4,6 @@ namespace Tests\Unit\Containers\PortStrategy;
 
 use Testcontainers\Containers\PortStrategy\StaticPortStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class StaticPortStrategyTest extends PortStrategyTestCase
 {
     public function resolvePortStrategy()

--- a/tests/Unit/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategyTest.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/IsRunningStartupCheckStrategyTest.php
@@ -4,11 +4,6 @@ namespace Tests\Unit\Containers\StartupCheckStrategy;
 
 use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class IsRunningStartupCheckStrategyTest extends StartupCheckStrategyTestCase
 {
     public function resolveStartupCheckStrategy()

--- a/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyProviderTest.php
+++ b/tests/Unit/Containers/StartupCheckStrategy/StartupCheckStrategyProviderTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\StartupCheckStrategy\AlreadyExistsStartupStrategyE
 use Testcontainers\Containers\StartupCheckStrategy\IsRunningStartupCheckStrategy;
 use Testcontainers\Containers\StartupCheckStrategy\StartupCheckStrategyProvider;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class StartupCheckStrategyProviderTest extends TestCase
 {
     public function testRegister()

--- a/tests/Unit/Containers/Types/HostToIpTest.php
+++ b/tests/Unit/Containers/Types/HostToIpTest.php
@@ -8,11 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\Types\HostToIp;
 use Testcontainers\Exceptions\InvalidFormatException;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class HostToIpTest extends TestCase
 {
     public function testHostToIp()

--- a/tests/Unit/Containers/Types/MountTest.php
+++ b/tests/Unit/Containers/Types/MountTest.php
@@ -7,11 +7,6 @@ namespace Tests\Unit\Containers\Types;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\Types\Mount;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class MountTest extends TestCase
 {
     public function testMount()

--- a/tests/Unit/Containers/Types/NetworkModeTest.php
+++ b/tests/Unit/Containers/Types/NetworkModeTest.php
@@ -5,11 +5,6 @@ namespace Tests\Unit\Containers\Types;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Containers\Types\NetworkMode;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class NetworkModeTest extends TestCase
 {
     public function testNetworkModeHost()

--- a/tests/Unit/Containers/Types/VolumeFromTest.php
+++ b/tests/Unit/Containers/Types/VolumeFromTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Containers\Types\BindMode;
 use Testcontainers\Containers\Types\VolumeFrom;
 use Testcontainers\Exceptions\InvalidFormatException;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class VolumeFromTest extends TestCase
 {
     public function testVolumeFrom()

--- a/tests/Unit/Containers/WaitStrategy/HostPortWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/HostPortWaitStrategyTest.php
@@ -8,11 +8,6 @@ use Testcontainers\Containers\WaitStrategy\PortProbe;
 use Testcontainers\Containers\WaitStrategy\WaitingTimeoutException;
 use Testcontainers\Docker\Types\ContainerId;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class HostPortWaitStrategyTest extends WaitStrategyTestCase
 {
     public function resolveWaitStrategy()

--- a/tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/HttpWaitStrategyTest.php
@@ -7,11 +7,6 @@ use Testcontainers\Containers\WaitStrategy\HttpProbe;
 use Testcontainers\Containers\WaitStrategy\HttpWaitStrategy;
 use Testcontainers\Docker\Types\ContainerId;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class HttpWaitStrategyTest extends WaitStrategyTestCase
 {
     public function resolveWaitStrategy()

--- a/tests/Unit/Containers/WaitStrategy/LogMessageWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/LogMessageWaitStrategyTest.php
@@ -7,11 +7,6 @@ use Testcontainers\Containers\WaitStrategy\LogMessageWaitStrategy;
 use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\Output\DockerRunWithDetachOutput;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class LogMessageWaitStrategyTest extends WaitStrategyTestCase
 {
     public function resolveWaitStrategy()

--- a/tests/Unit/Containers/WaitStrategy/PDO/MySQLDSNTest.php
+++ b/tests/Unit/Containers/WaitStrategy/PDO/MySQLDSNTest.php
@@ -4,11 +4,6 @@ namespace Tests\Unit\Containers\WaitStrategy\PDO;
 
 use Testcontainers\Containers\WaitStrategy\PDO\MySQLDSN;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class MySQLDSNTest extends DSNTestCase
 {
     public function resolveDSN()

--- a/tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php
+++ b/tests/Unit/Containers/WaitStrategy/PDO/PDOConnectWaitStrategyTest.php
@@ -8,11 +8,6 @@ use Testcontainers\Containers\WaitStrategy\PDO\SQLiteDSN;
 use Testcontainers\Docker\Types\ContainerId;
 use Tests\Unit\Containers\WaitStrategy\WaitStrategyTestCase;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class PDOConnectWaitStrategyTest extends WaitStrategyTestCase
 {
     public function resolveWaitStrategy()

--- a/tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php
+++ b/tests/Unit/Containers/WaitStrategy/WaitStrategyProviderTest.php
@@ -10,11 +10,6 @@ use Testcontainers\Containers\WaitStrategy\WaitStrategy;
 use Testcontainers\Containers\WaitStrategy\WaitStrategyProvider;
 use Testcontainers\Utility\WithLogger;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class WaitStrategyProviderTest extends TestCase
 {
     public function testRegister()

--- a/tests/Unit/Docker/Command/BaseCommandTest.php
+++ b/tests/Unit/Docker/Command/BaseCommandTest.php
@@ -5,11 +5,6 @@ namespace Tests\Unit\Docker\Command;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Docker\DockerClient;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class BaseCommandTest extends TestCase
 {
     public function testGetHostFromDefault()

--- a/tests/Unit/Docker/Command/InspectCommandTest.php
+++ b/tests/Unit/Docker/Command/InspectCommandTest.php
@@ -8,11 +8,6 @@ use Testcontainers\Docker\DockerClient;
 use Testcontainers\Docker\Output\DockerInspectOutput;
 use Testcontainers\Docker\Output\DockerRunWithDetachOutput;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class InspectCommandTest extends TestCase
 {
     public function testHasInspectCommandTrait()

--- a/tests/Unit/Docker/Command/LogsCommandTest.php
+++ b/tests/Unit/Docker/Command/LogsCommandTest.php
@@ -11,11 +11,6 @@ use Testcontainers\Docker\Output\DockerRunWithDetachOutput;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class LogsCommandTest extends TestCase
 {
     public function testHasLogsCommandTrait()

--- a/tests/Unit/Docker/Command/NetworkCreateCommandTest.php
+++ b/tests/Unit/Docker/Command/NetworkCreateCommandTest.php
@@ -9,11 +9,6 @@ use Testcontainers\Docker\Output\DockerNetworkCreateOutput;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class NetworkCreateCommandTest extends TestCase
 {
     public function testHasNetworkCreateCommandTrait()

--- a/tests/Unit/Docker/Command/RunCommandTest.php
+++ b/tests/Unit/Docker/Command/RunCommandTest.php
@@ -11,11 +11,6 @@ use Testcontainers\Docker\Output\DockerRunWithDetachOutput;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class RunCommandTest extends TestCase
 {
     public function testHasRunCommandTrait()

--- a/tests/Unit/Docker/Command/StopCommandTest.php
+++ b/tests/Unit/Docker/Command/StopCommandTest.php
@@ -11,11 +11,6 @@ use Testcontainers\Docker\Output\DockerStopOutput;
 use Testcontainers\Testcontainers;
 use Tests\Images\DinD;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class StopCommandTest extends TestCase
 {
     public function testHasStopCommandTrait()

--- a/tests/Unit/Docker/DockerClientTest.php
+++ b/tests/Unit/Docker/DockerClientTest.php
@@ -5,11 +5,6 @@ namespace Tests\Unit\Docker;
 use PHPUnit\Framework\TestCase;
 use Testcontainers\Docker\DockerClient;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class DockerClientTest extends TestCase
 {
     public function testClone()

--- a/tests/Unit/TestcontainersTest.php
+++ b/tests/Unit/TestcontainersTest.php
@@ -6,11 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Testcontainers\Testcontainers;
 use Tests\Images\AlpineContainer;
 
-/**
- * @internal
- *
- * @coversNothing
- */
 class TestcontainersTest extends TestCase
 {
     public function testWithContainerClassString()


### PR DESCRIPTION
This pull request introduces several updates to improve testing configurations and streamline test files. The most notable changes include adding a test coverage command, updating the PHPUnit configuration, and removing unnecessary annotations from test classes.

### Testing Configuration Updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R49): Added a new script command, `"coverage"`, to generate test coverage reports using PHPUnit.
* [`phpunit.xml.dist`](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L3-R3): Updated the PHPUnit schema URL to an older version (`5.7`) for compatibility and added a whitelist filter to include the `src/` directory in coverage analysis. [[1]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L3-R3) [[2]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892R28-R33)

### Test File Simplifications:

* Removed `@internal` and `@coversNothing` annotations from various test classes across multiple files to declutter and simplify the test codebase. These changes affect files such as `DockerExecutorTest.php`, `MachineExecutorTest.php`, and numerous unit test files under `GenericContainer`. [[1]](diffhunk://#diff-5db438f238b601554d37a4f46945e2120892acf5ea221d43644db771a13c4889L14-L18) [[2]](diffhunk://#diff-fb1b37251386d3665b30a191ef138e1ba66679ae97b2c61ccc3fff5f881596b9L14-L18) [[3]](diffhunk://#diff-64f97ffba42e56cc720d315d413a04ee1ed53db6eb23684618536efcef831e08L11-L15) [[4]](diffhunk://#diff-46505daafb0958ac4fd5664db3d0de04fd4e461b9ab4eeaa6e0efd2874261a8cL11-L15) [[5]](diffhunk://#diff-2825007639ab57bf2a2712e0a3a161c3afee563d2a4f53839f54b513c303b9a3L12-L16) [[6]](diffhunk://#diff-877e11b915cceb9882309403855688f0961ac5847b0b0f39ccdbffb2c050315bL12-L16) [[7]](diffhunk://#diff-7d00d6530ad878388bf7ec66484b2c260951a5adc842063e70bb5886d3dc1e60L12-L16) [[8]](diffhunk://#diff-fc0e3a06fbf2d04464614adac10700cd8f3ffb7f3be556a39502dafb8c8d9087L15-L19) [[9]](diffhunk://#diff-fc405504e6ec9985f45033d106f4181d527ecb209d865e4dd78a0220d55d7843L15-L19) [[10]](diffhunk://#diff-736e06f195d703a3f0a1d39d84bcbaf94f51af17b5f74def39616a5a0c674081L12-L16) [[11]](diffhunk://#diff-133b9d09ec4efa6b592fec897a0a6ab78643cde80e5534fa1edf57f267e88317L12-L16) [[12]](diffhunk://#diff-36977976ec3f7a5fe86736e2b5b206938c576f5bd2e6b0363687f63bccd8545bL11-L15) [[13]](diffhunk://#diff-4597ca68365d6df00d6a6e0e4e49c8ee9ad50d1540edad807ec3a254c76aadd5L12-L16) [[14]](diffhunk://#diff-6ac9b9271dfa9ae607f0bad747456c08a45aaaac2593ebe0788c805e6a2baee8L13-L17) [[15]](diffhunk://#diff-30b47d8fd6b5e5814efef8d2a47cda2c8057206f9cffe06f7b74ec55fdcd8bd8L16-L20) [[16]](diffhunk://#diff-c0ae47508a67e669fb15e5da3f8afff1ad2e7e906736c4a870ce418a1a0fa2adL12-L16) [[17]](diffhunk://#diff-502046c9d5725808f30ac95c91e81d43e2f8cb98ea182569ca56288aa0ce56caL12-L16) [[18]](diffhunk://#diff-83bbb1c48fd9558179d2ad88a7bc1e503e919360f09f50600e392f1bc5fa8497L18-L22)