### PR TITLE
Improve documentation for startup checks, logging, and SSH port forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,7 @@ composer.lock
 
 # VSCode
 .vscode/
+
+# Copilot
+.github/copilot-instructions.md
+.task/

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -119,6 +119,8 @@ When using the Docker Executor with Remote Docker, you need to set the following
 - `TESTCONTAINERS_SSH_FEEDFORWARDING`: Enables SSH port forwarding
 - `TESTCONTAINERS_HOST_OVERRIDE`: Makes container ports accessible via localhost
 
+For more details on `TESTCONTAINERS_SSH_FEEDFORWARDING` and related configurations, see the [Environments](environments.md) and [Container Configuration](container-configuration.md#ssh-port-forward-settings) documentation.
+
 If you need to explicitly configure SSH port forwarding in your test code, you can use `withSSHPortForward`:
 
 ```php


### PR DESCRIPTION
This pull request updates the documentation for `testcontainers-php` with enhancements to configuration options, logging capabilities, and examples. The changes aim to provide clearer guidance on using startup check strategies, SSH port forwarding, and logging with PSR-3 compatibility.

### Enhancements to Configuration Options:
* [`docs/container-configuration.md`](diffhunk://#diff-d0af6c057bc5cf9db670d913968c7a2b184f08ec34315e1f6718904e4465a681L519-R519): Expanded the description of `IsRunningStartupCheckStrategy` to include timeout and retry interval configuration. Added examples demonstrating how to set these options using the fluent API. [[1]](diffhunk://#diff-d0af6c057bc5cf9db670d913968c7a2b184f08ec34315e1f6718904e4465a681L519-R519) [[2]](diffhunk://#diff-d0af6c057bc5cf9db670d913968c7a2b184f08ec34315e1f6718904e4465a681L533-R533) [[3]](diffhunk://#diff-d0af6c057bc5cf9db670d913968c7a2b184f08ec34315e1f6718904e4465a681L546-R558)

### SSH Port Forwarding Documentation:
* [`docs/ci-setup.md`](diffhunk://#diff-93212b8403ec1c28065aae23e76c992a97dc40a94e11659ab93cb3d28b055b17R122-R123): Added references to related documentation for configuring `TESTCONTAINERS_SSH_FEEDFORWARDING` and SSH port forwarding settings.

### Logging Capabilities:
* [`docs/container-configuration.md`](diffhunk://#diff-d0af6c057bc5cf9db670d913968c7a2b184f08ec34315e1f6718904e4465a681R694-R734): Introduced PSR-3 compatible logging support, including examples of using a custom logger with containers and wait strategies. This addition helps centralize logging and provides insights into container lifecycle events and strategy executions.